### PR TITLE
feat(product-location): manage locations modal with checkbox sync

### DIFF
--- a/app/Livewire/Products/Index.php
+++ b/app/Livewire/Products/Index.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Products;
 
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\Warehouse;
 use Flux\Flux;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
@@ -19,6 +20,7 @@ class Index extends Component
 
     public ?int $filterCategory = null;
 
+    // Create/Edit modal
     public bool $showModal = false;
 
     public ?int $editingId = null;
@@ -32,6 +34,13 @@ class Index extends Component
     public string $description = '';
 
     public ?int $minStock = 0;
+
+    // Locations modal
+    public bool $showLocationsModal = false;
+
+    public ?int $managingProductId = null;
+
+    public array $selectedLocations = [];
 
     public function updatedSearch(): void
     {
@@ -61,6 +70,20 @@ class Index extends Component
             ->paginate(10);
     }
 
+    #[Computed]
+    public function warehousesWithLocations()
+    {
+        return Warehouse::with('locations')->orderBy('name')->get();
+    }
+
+    #[Computed]
+    public function managingProduct(): ?Product
+    {
+        return $this->managingProductId
+            ? Product::with('locations')->find($this->managingProductId)
+            : null;
+    }
+
     public function openCreate(): void
     {
         $this->reset(['name', 'sku', 'categoryId', 'description', 'minStock', 'editingId']);
@@ -79,6 +102,25 @@ class Index extends Component
         $this->minStock = $product->min_stock;
         $this->resetValidation();
         $this->showModal = true;
+    }
+
+    public function openLocations(Product $product): void
+    {
+        $this->managingProductId = $product->id;
+        $this->selectedLocations = $product->locations()->pluck('locations.id')->map(fn ($id) => (string) $id)->toArray();
+        unset($this->managingProduct);
+        $this->showLocationsModal = true;
+    }
+
+    public function saveLocations(): void
+    {
+        $product = Product::findOrFail($this->managingProductId);
+        $product->locations()->sync($this->selectedLocations);
+        activity()->causedBy(auth()->user())->performedOn($product)->log('locations updated');
+        Flux::toast(__('Locations updated.'), variant: 'success');
+        $this->showLocationsModal = false;
+        $this->reset(['managingProductId', 'selectedLocations']);
+        unset($this->managingProduct, $this->products);
     }
 
     public function save(): void

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -71,6 +71,12 @@
                                 >
                                     {{ __('Edit') }}
                                 </flux:menu.item>
+                                <flux:menu.item
+                                    icon="map-pin"
+                                    wire:click="openLocations({{ $product->id }})"
+                                >
+                                    {{ __('Manage Locations') }}
+                                </flux:menu.item>
                                 <flux:menu.separator />
                                 <flux:menu.item
                                     icon="trash"
@@ -149,6 +155,64 @@
                 <flux:button wire:click="save" variant="primary">
                     {{ $editingId ? __('Update') : __('Create') }}
                 </flux:button>
+            </div>
+        </div>
+    </flux:modal>
+
+    {{-- Manage Locations Modal --}}
+    <flux:modal wire:model="showLocationsModal" class="max-w-lg">
+        <div class="flex flex-col gap-6 p-6">
+            <div>
+                <flux:heading size="lg">{{ __('Manage Locations') }}</flux:heading>
+                @if($this->managingProduct)
+                    <flux:subheading>{{ $this->managingProduct->name }} ({{ $this->managingProduct->sku }})</flux:subheading>
+                @endif
+            </div>
+
+            @if($this->warehousesWithLocations->isEmpty())
+                <flux:text class="text-zinc-500">{{ __('No warehouses or locations available. Create them first.') }}</flux:text>
+            @else
+                <div class="flex flex-col gap-4 max-h-80 overflow-y-auto">
+                    @foreach($this->warehousesWithLocations as $warehouse)
+                        @if($warehouse->locations->isNotEmpty())
+                            <div>
+                                <flux:text class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                                    {{ $warehouse->name }} — {{ $warehouse->location }}
+                                </flux:text>
+                                <div class="flex flex-col gap-1">
+                                    @foreach($warehouse->locations as $location)
+                                        <label class="flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800">
+                                            <flux:checkbox
+                                                wire:model="selectedLocations"
+                                                value="{{ $location->id }}"
+                                            />
+                                            <span class="text-sm">
+                                                <span class="font-medium">{{ $location->code }}</span>
+                                                @if($location->name)
+                                                    <span class="text-zinc-400"> — {{ $location->name }}</span>
+                                                @endif
+                                            </span>
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endif
+                    @endforeach
+                </div>
+            @endif
+
+            <div class="flex items-center justify-between">
+                <flux:text class="text-sm text-zinc-400">
+                    {{ count($selectedLocations) }} {{ __('selected') }}
+                </flux:text>
+                <div class="flex gap-3">
+                    <flux:button wire:click="$set('showLocationsModal', false)" variant="ghost">
+                        {{ __('Cancel') }}
+                    </flux:button>
+                    <flux:button wire:click="saveLocations" variant="primary">
+                        {{ __('Save') }}
+                    </flux:button>
+                </div>
             </div>
         </div>
     </flux:modal>

--- a/tests/Feature/ProductLocationTest.php
+++ b/tests/Feature/ProductLocationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Livewire\Products\Index;
+use App\Models\Category;
+use App\Models\Location;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Warehouse;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->admin = User::factory()->admin()->create();
+    $this->category = Category::factory()->create();
+    $this->warehouse = Warehouse::factory()->create();
+    $this->locationA = Location::factory()->create(['warehouse_id' => $this->warehouse->id, 'code' => 'AA-01']);
+    $this->locationB = Location::factory()->create(['warehouse_id' => $this->warehouse->id, 'code' => 'AA-02']);
+    $this->product = Product::factory()->create(['category_id' => $this->category->id]);
+});
+
+test('admin can open manage locations modal', function () {
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openLocations', $this->product)
+        ->assertSet('showLocationsModal', true)
+        ->assertSet('managingProductId', $this->product->id);
+});
+
+test('manage locations modal preloads existing locations', function () {
+    $this->product->locations()->attach($this->locationA->id);
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openLocations', $this->product)
+        ->assertSet('selectedLocations', [(string) $this->locationA->id]);
+});
+
+test('admin can assign locations to a product', function () {
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openLocations', $this->product)
+        ->set('selectedLocations', [(string) $this->locationA->id, (string) $this->locationB->id])
+        ->call('saveLocations')
+        ->assertSet('showLocationsModal', false);
+
+    expect($this->product->fresh()->locations()->count())->toBe(2);
+});
+
+test('saving locations syncs and removes deselected ones', function () {
+    $this->product->locations()->attach([$this->locationA->id, $this->locationB->id]);
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openLocations', $this->product)
+        ->set('selectedLocations', [(string) $this->locationA->id])
+        ->call('saveLocations');
+
+    expect($this->product->fresh()->locations()->count())->toBe(1);
+    expect($this->product->fresh()->locations()->first()->id)->toBe($this->locationA->id);
+});
+
+test('admin can clear all locations from a product', function () {
+    $this->product->locations()->attach($this->locationA->id);
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openLocations', $this->product)
+        ->set('selectedLocations', [])
+        ->call('saveLocations');
+
+    expect($this->product->fresh()->locations()->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- Adds "Manage Locations" modal on the Products page
- Checkboxes per warehouse/location, pre-loads existing linked locations
- Saves via `sync()` — adds new, removes deselected in one call
- Logs activity on every save

## Tests
- 5 new Pest tests in `ProductLocationTest.php` (open modal, preload, assign, sync/remove, clear all)
- All 79 tests passing