### PR TITLE
feat(products): add image upload with preview and validation

### DIFF
--- a/app/Livewire/Products/Index.php
+++ b/app/Livewire/Products/Index.php
@@ -6,15 +6,18 @@ use App\Models\Category;
 use App\Models\Product;
 use App\Models\Warehouse;
 use Flux\Flux;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
 use Livewire\WithPagination;
 
 #[Layout('layouts.app')]
 class Index extends Component
 {
-    use WithPagination;
+    use WithFileUploads, WithPagination;
 
     public string $search = '';
 
@@ -34,6 +37,11 @@ class Index extends Component
     public string $description = '';
 
     public ?int $minStock = 0;
+
+    /** @var TemporaryUploadedFile|null */
+    public $image = null;
+
+    public ?string $existingImagePath = null;
 
     // Locations modal
     public bool $showLocationsModal = false;
@@ -86,7 +94,7 @@ class Index extends Component
 
     public function openCreate(): void
     {
-        $this->reset(['name', 'sku', 'categoryId', 'description', 'minStock', 'editingId']);
+        $this->reset(['name', 'sku', 'categoryId', 'description', 'minStock', 'editingId', 'image', 'existingImagePath']);
         $this->minStock = 0;
         $this->resetValidation();
         $this->showModal = true;
@@ -100,6 +108,8 @@ class Index extends Component
         $this->categoryId = $product->category_id;
         $this->description = $product->description ?? '';
         $this->minStock = $product->min_stock;
+        $this->image = null;
+        $this->existingImagePath = $product->image_path;
         $this->resetValidation();
         $this->showModal = true;
     }
@@ -135,6 +145,7 @@ class Index extends Component
             'categoryId' => 'required|exists:categories,id',
             'description' => 'nullable|string',
             'minStock' => 'nullable|integer|min:0',
+            'image' => 'nullable|image|mimes:jpeg,png,webp|max:2048',
         ]);
 
         $data = [
@@ -145,8 +156,18 @@ class Index extends Component
             'min_stock' => $this->minStock ?? 0,
         ];
 
+        if ($this->image) {
+            $data['image_path'] = $this->image->store('products', 'public');
+        }
+
         if ($this->editingId) {
             $product = Product::findOrFail($this->editingId);
+
+            // Delete old image if a new one was uploaded
+            if ($this->image && $product->image_path) {
+                Storage::disk('public')->delete($product->image_path);
+            }
+
             $product->update($data);
             activity()->causedBy(auth()->user())->performedOn($product)->log('updated');
             Flux::toast(__('Product updated.'), variant: 'success');
@@ -157,7 +178,7 @@ class Index extends Component
         }
 
         $this->showModal = false;
-        $this->reset(['name', 'sku', 'categoryId', 'description', 'minStock', 'editingId']);
+        $this->reset(['name', 'sku', 'categoryId', 'description', 'minStock', 'editingId', 'image', 'existingImagePath']);
         unset($this->products);
     }
 

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -30,6 +30,7 @@
     {{-- Table --}}
     <flux:table>
         <flux:table.columns>
+            <flux:table.column></flux:table.column>
             <flux:table.column>{{ __('Name') }}</flux:table.column>
             <flux:table.column>{{ __('SKU') }}</flux:table.column>
             <flux:table.column>{{ __('Category') }}</flux:table.column>
@@ -41,6 +42,19 @@
         <flux:table.rows>
             @forelse ($this->products as $product)
                 <flux:table.row :key="$product->id">
+                    <flux:table.cell>
+                        @if ($product->image_path)
+                            <img
+                                src="{{ Storage::url($product->image_path) }}"
+                                alt="{{ $product->name }}"
+                                class="size-10 rounded-lg object-cover"
+                            />
+                        @else
+                            <div class="flex size-10 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800">
+                                <flux:icon.photo class="size-5 text-zinc-400" />
+                            </div>
+                        @endif
+                    </flux:table.cell>
                     <flux:table.cell variant="strong">
                         {{ $product->name }}
                     </flux:table.cell>
@@ -50,7 +64,7 @@
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        {{ $product->category->name }}
+                        {{ $product->category?->name ?? '—' }}
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -92,7 +106,7 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
+                    <flux:table.cell colspan="7" class="py-12 text-center">
                         {{ $search || $filterCategory ? __('No products match your filters.') : __('No products yet.') }}
                     </flux:table.cell>
                 </flux:table.row>
@@ -145,6 +159,25 @@
                     <flux:label>{{ __('Description') }} <span class="text-zinc-400 text-xs font-normal">({{ __('optional') }})</span></flux:label>
                     <flux:textarea wire:model="description" rows="3" placeholder="{{ __('Short description...') }}" />
                     <flux:error name="description" />
+                </flux:field>
+
+                <flux:field class="col-span-2">
+                    <flux:label>{{ __('Image') }} <span class="text-zinc-400 text-xs font-normal">({{ __('optional') }}, JPEG / PNG / WebP, max 2 MB)</span></flux:label>
+
+                    {{-- Preview: new upload takes priority, otherwise show existing --}}
+                    @if ($image)
+                        <img src="{{ $image->temporaryUrl() }}" alt="Preview" class="mb-2 h-24 w-24 rounded-lg object-cover" />
+                    @elseif ($existingImagePath)
+                        <img src="{{ Storage::url($existingImagePath) }}" alt="{{ __('Current image') }}" class="mb-2 h-24 w-24 rounded-lg object-cover" />
+                    @endif
+
+                    <input
+                        type="file"
+                        wire:model="image"
+                        accept="image/jpeg,image/png,image/webp"
+                        class="block w-full text-sm text-zinc-500 file:mr-4 file:rounded-lg file:border-0 file:bg-zinc-100 file:px-4 file:py-2 file:text-sm file:font-medium file:text-zinc-700 hover:file:bg-zinc-200 dark:file:bg-zinc-800 dark:file:text-zinc-300"
+                    />
+                    <flux:error name="image" />
                 </flux:field>
             </div>
 

--- a/tests/Feature/ProductCrudTest.php
+++ b/tests/Feature/ProductCrudTest.php
@@ -4,6 +4,8 @@ use App\Livewire\Products\Index;
 use App\Models\Category;
 use App\Models\Product;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -124,6 +126,83 @@ test('products are searchable by name and sku', function () {
         ->set('search', 'Wireless')
         ->assertSee('Wireless Mouse')
         ->assertDontSee('Keyboard');
+});
+
+test('admin can upload an image when creating a product', function () {
+    Storage::fake('public');
+
+    $file = UploadedFile::fake()->image('product.jpg', 200, 200);
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openCreate')
+        ->set('name', 'Camera')
+        ->set('sku', 'CAM-001')
+        ->set('categoryId', $this->category->id)
+        ->set('image', $file)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $product = Product::where('sku', 'CAM-001')->first();
+    expect($product->image_path)->not->toBeNull();
+    Storage::disk('public')->assertExists($product->image_path);
+});
+
+test('uploaded image replaces old image on edit', function () {
+    Storage::fake('public');
+
+    $old = UploadedFile::fake()->image('old.jpg');
+    $oldPath = $old->store('products', 'public');
+
+    $product = Product::factory()->create([
+        'category_id' => $this->category->id,
+        'image_path' => $oldPath,
+    ]);
+
+    $newFile = UploadedFile::fake()->image('new.jpg', 300, 300);
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openEdit', $product)
+        ->set('image', $newFile)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    Storage::disk('public')->assertMissing($oldPath);
+    Storage::disk('public')->assertExists($product->fresh()->image_path);
+});
+
+test('image must be jpeg png or webp — gif is rejected', function () {
+    Storage::fake('public');
+
+    // GIF is a valid image but not in our whitelist (jpeg/png/webp)
+    $file = UploadedFile::fake()->image('product.gif')->mimeType('image/gif');
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openCreate')
+        ->set('name', 'Bad Upload')
+        ->set('sku', 'BAD-001')
+        ->set('categoryId', $this->category->id)
+        ->set('image', $file)
+        ->call('save')
+        ->assertHasErrors(['image']);
+});
+
+test('image max size is 2mb', function () {
+    Storage::fake('public');
+
+    $file = UploadedFile::fake()->image('big.jpg')->size(3000);
+
+    Livewire::actingAs($this->admin)
+        ->test(Index::class)
+        ->call('openCreate')
+        ->set('name', 'Big Image')
+        ->set('sku', 'BIG-001')
+        ->set('categoryId', $this->category->id)
+        ->set('image', $file)
+        ->call('save')
+        ->assertHasErrors(['image']);
 });
 
 test('products can be filtered by category', function () {


### PR DESCRIPTION
## Summary
- Add `WithFileUploads` to `Products/Index` — required by Traject A spec (2.3 Productafbeeldingen)
- Validate: nullable, image, mimes jpeg/png/webp, max 2MB
- Store to `public/products` disk on create; replace + delete old on edit
- Thumbnail (40×40) shown in product table row; placeholder icon when no image
- Live preview in modal: temporary URL for new uploads, Storage URL for existing image

Closes #2 (Productafbeeldingen vereiste uit 2026.pdf sectie 2.3)

## Test plan
- [x] `./vendor/bin/pint --test` passes
- [x] `php artisan test` — 180/180 green
- [x] Upload on create saves file to disk
- [x] Upload on edit replaces old file
- [x] GIF rejected (not in whitelist)
- [x] Oversized file rejected