### PR TITLE
feat(ui): full UI overhaul — cards, detail pages, visual polish

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -5,7 +5,9 @@ namespace App\Livewire;
 use App\Models\Category;
 use App\Models\Location;
 use App\Models\Product;
+use App\Models\StockMovement;
 use App\Models\Warehouse;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -17,11 +19,16 @@ class Dashboard extends Component
     #[Computed]
     public function stats(): array
     {
+        $totalStock = (int) DB::table('stock')->sum('quantity');
+        $movementsToday = StockMovement::whereDate('created_at', today())->count();
+
         return [
             'products' => Product::count(),
             'categories' => Category::count(),
             'warehouses' => Warehouse::count(),
             'locations' => Location::count(),
+            'total_stock' => $totalStock,
+            'movements_today' => $movementsToday,
         ];
     }
 

--- a/app/Livewire/Warehouses/Index.php
+++ b/app/Livewire/Warehouses/Index.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Warehouses;
 
 use App\Models\Warehouse;
 use Flux\Flux;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Rule;
@@ -38,7 +39,10 @@ class Index extends Component
     #[Computed]
     public function warehouses()
     {
+        $totalStockSub = DB::raw('(SELECT COALESCE(SUM(s.quantity), 0) FROM stock s INNER JOIN locations l ON s.location_id = l.id WHERE l.warehouse_id = warehouses.id AND l.deleted_at IS NULL) as total_stock');
+
         return Warehouse::query()
+            ->addSelect(['warehouses.*', $totalStockSub])
             ->when($this->search, fn ($q) => $q->where('name', 'like', "%{$this->search}%")
                 ->orWhere('location', 'like', "%{$this->search}%"))
             ->withCount('locations')

--- a/app/Livewire/Warehouses/Show.php
+++ b/app/Livewire/Warehouses/Show.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Livewire\Warehouses;
+
+use App\Models\Location;
+use App\Models\Warehouse;
+use Flux\Flux;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class Show extends Component
+{
+    public Warehouse $warehouse;
+
+    // Add location modal
+    public bool $showModal = false;
+
+    public ?int $editingLocationId = null;
+
+    public string $code = '';
+
+    public string $locationName = '';
+
+    public function mount(Warehouse $warehouse): void
+    {
+        $this->warehouse = $warehouse;
+    }
+
+    #[Computed]
+    public function locations()
+    {
+        $totalStockSub = DB::raw('(SELECT COALESCE(SUM(s.quantity), 0) FROM stock s WHERE s.location_id = locations.id) as total_stock');
+        $productCountSub = DB::raw('(SELECT COUNT(DISTINCT s.product_id) FROM stock s WHERE s.location_id = locations.id AND s.quantity > 0) as product_count');
+
+        return $this->warehouse->locations()
+            ->addSelect(['locations.*', $totalStockSub, $productCountSub])
+            ->orderBy('code')
+            ->get();
+    }
+
+    #[Computed]
+    public function stats(): array
+    {
+        $locations = $this->locations;
+
+        return [
+            'location_count' => $locations->count(),
+            'total_stock' => $locations->sum('total_stock'),
+            'product_count' => DB::table('stock')
+                ->join('locations', 'stock.location_id', '=', 'locations.id')
+                ->where('locations.warehouse_id', $this->warehouse->id)
+                ->whereNull('locations.deleted_at')
+                ->distinct('stock.product_id')
+                ->count('stock.product_id'),
+        ];
+    }
+
+    public function openCreateLocation(): void
+    {
+        $this->reset(['code', 'locationName', 'editingLocationId']);
+        $this->resetValidation();
+        $this->showModal = true;
+    }
+
+    public function openEditLocation(Location $location): void
+    {
+        $this->editingLocationId = $location->id;
+        $this->code = $location->code;
+        $this->locationName = $location->name ?? '';
+        $this->resetValidation();
+        $this->showModal = true;
+    }
+
+    public function saveLocation(): void
+    {
+        $this->validate([
+            'code' => 'required|string|max:20',
+            'locationName' => 'nullable|string|max:100',
+        ]);
+
+        if ($this->editingLocationId) {
+            $loc = Location::findOrFail($this->editingLocationId);
+            $loc->update([
+                'code' => strtoupper($this->code),
+                'name' => $this->locationName ?: null,
+            ]);
+            activity()->causedBy(auth()->user())->performedOn($loc)->log('updated');
+            Flux::toast(__('Location updated.'), variant: 'success');
+        } else {
+            $loc = $this->warehouse->locations()->create([
+                'code' => strtoupper($this->code),
+                'name' => $this->locationName ?: null,
+            ]);
+            activity()->causedBy(auth()->user())->performedOn($loc)->log('created');
+            Flux::toast(__('Location created.'), variant: 'success');
+        }
+
+        $this->showModal = false;
+        $this->reset(['code', 'locationName', 'editingLocationId']);
+        unset($this->locations, $this->stats);
+    }
+
+    public function deleteLocation(Location $location): void
+    {
+        $location->delete();
+        activity()->causedBy(auth()->user())->performedOn($location)->log('deleted');
+        Flux::toast(__('Location deleted.'), variant: 'success');
+        unset($this->locations, $this->stats);
+    }
+
+    public function render()
+    {
+        return view('livewire.warehouses.show');
+    }
+}

--- a/resources/views/livewire/categories/index.blade.php
+++ b/resources/views/livewire/categories/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Categories') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Categories') }}</flux:heading>
+            <flux:subheading>{{ __('Organise your products into logical groups') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Category') }}
         </flux:button>
@@ -31,15 +34,22 @@
             @forelse ($this->categories as $category)
                 <flux:table.row :key="$category->id">
                     <flux:table.cell variant="strong">
-                        {{ $category->name }}
+                        <div class="flex items-center gap-2.5">
+                            <div class="rounded-md bg-violet-50 p-1.5 dark:bg-violet-900/30">
+                                <flux:icon.tag class="size-4 text-violet-600 dark:text-violet-400" />
+                            </div>
+                            {{ $category->name }}
+                        </div>
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        {{ $category->description ?? '—' }}
+                        <span class="text-zinc-500">{{ $category->description ?? '—' }}</span>
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        <flux:badge variant="outline">{{ $category->products_count }}</flux:badge>
+                        <flux:badge variant="{{ $category->products_count > 0 ? 'outline' : 'ghost' }}">
+                            {{ $category->products_count }} {{ __('products') }}
+                        </flux:badge>
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -71,8 +81,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="5" class="py-12 text-center">
-                        {{ $search ? __('No categories match your search.') : __('No categories yet.') }}
+                    <flux:table.cell colspan="5" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.tag class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $search ? __('No categories match your search.') : __('No categories yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,130 +1,216 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
-    {{-- Header --}}
-    <div>
-        <flux:heading size="xl">{{ __('Dashboard') }}</flux:heading>
-        <flux:subheading>{{ __('Welcome back,') }} {{ auth()->user()->name }}</flux:subheading>
+    {{-- Hero header --}}
+    <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-blue-600 to-blue-800 px-6 py-8 text-white shadow-lg dark:from-blue-700 dark:to-blue-900">
+        <div class="relative z-10">
+            <p class="text-sm font-medium text-blue-200">{{ now()->format('l, j F Y') }}</p>
+            <h1 class="mt-1 text-3xl font-bold">{{ __('Welcome back,') }} {{ auth()->user()->name }} 👋</h1>
+            <p class="mt-1 text-blue-200">{{ __('Here\'s what\'s happening in your warehouses today.') }}</p>
+        </div>
+        {{-- Decorative circles --}}
+        <div class="absolute -right-8 -top-8 size-40 rounded-full bg-white/5"></div>
+        <div class="absolute -bottom-10 right-20 size-28 rounded-full bg-white/5"></div>
     </div>
 
-    {{-- Stats Cards --}}
+    {{-- Stats grid --}}
     @php $isAdmin = auth()->user()->isAdmin(); @endphp
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <a href="{{ $isAdmin ? route('products.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-blue-100 p-3 dark:bg-blue-900/30">
-                    <flux:icon.archive-box class="size-6 text-blue-600 dark:text-blue-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Products') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['products'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
 
-        <a href="{{ $isAdmin ? route('categories.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-purple-100 p-3 dark:bg-purple-900/30">
-                    <flux:icon.tag class="size-6 text-purple-600 dark:text-purple-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Categories') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['categories'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+        {{-- Total stock (wide) --}}
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-xl bg-emerald-50 p-3 dark:bg-emerald-900/30">
+                <flux:icon.cube class="size-7 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <div>
+                <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100">{{ number_format($this->stats['total_stock']) }}</p>
+                <p class="text-sm text-zinc-500">{{ __('Items in stock') }}</p>
+            </div>
+        </div>
 
-        <a href="{{ $isAdmin ? route('warehouses.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-amber-100 p-3 dark:bg-amber-900/30">
-                    <flux:icon.building-office class="size-6 text-amber-600 dark:text-amber-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Warehouses') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['warehouses'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+        {{-- Movements today (wide) --}}
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
+                <flux:icon.arrow-path class="size-7 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+                <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['movements_today'] }}</p>
+                <p class="text-sm text-zinc-500">{{ __('Movements today') }}</p>
+            </div>
+        </div>
 
-        <a href="{{ $isAdmin ? route('locations.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-green-100 p-3 dark:bg-green-900/30">
-                    <flux:icon.map-pin class="size-6 text-green-600 dark:text-green-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Locations') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['locations'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+        {{-- Low stock alert count (wide) --}}
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border {{ $this->lowStockProducts->isNotEmpty() ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900' }} p-5">
+            <div class="rounded-xl {{ $this->lowStockProducts->isNotEmpty() ? 'bg-red-100 dark:bg-red-900/30' : 'bg-zinc-100 dark:bg-zinc-800' }} p-3">
+                <flux:icon.exclamation-triangle class="size-7 {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-600 dark:text-red-400' : 'text-zinc-400' }}" />
+            </div>
+            <div>
+                <p class="text-3xl font-bold {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-700 dark:text-red-400' : 'text-zinc-900 dark:text-zinc-100' }}">{{ $this->lowStockProducts->count() }}</p>
+                <p class="text-sm {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-500' : 'text-zinc-500' }}">{{ __('Low stock alerts') }}</p>
+            </div>
+        </div>
     </div>
 
-    {{-- Bottom Grid --}}
+    {{-- Small counters --}}
+    <div class="grid gap-4 sm:grid-cols-4">
+        @if($isAdmin)
+        <a href="{{ route('products.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-blue-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-700">
+            <div class="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
+                <flux:icon.archive-box class="size-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['products'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Products') }}</p>
+            </div>
+        </a>
+        <a href="{{ route('categories.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-violet-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-violet-700">
+            <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
+                <flux:icon.tag class="size-5 text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['categories'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Categories') }}</p>
+            </div>
+        </a>
+        <a href="{{ route('warehouses.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-amber-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-amber-700">
+            <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <flux:icon.building-office class="size-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['warehouses'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Warehouses') }}</p>
+            </div>
+        </a>
+        <a href="{{ route('locations.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-green-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-green-700">
+            <div class="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
+                <flux:icon.map-pin class="size-5 text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['locations'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Locations') }}</p>
+            </div>
+        </a>
+        @else
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
+                <flux:icon.archive-box class="size-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['products'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Products') }}</p>
+            </div>
+        </div>
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
+                <flux:icon.tag class="size-5 text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['categories'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Categories') }}</p>
+            </div>
+        </div>
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <flux:icon.building-office class="size-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['warehouses'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Warehouses') }}</p>
+            </div>
+        </div>
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
+                <flux:icon.map-pin class="size-5 text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['locations'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Locations') }}</p>
+            </div>
+        </div>
+        @endif
+    </div>
+
+    {{-- Bottom grid --}}
     <div class="grid gap-6 lg:grid-cols-2">
 
         {{-- Low Stock Alerts --}}
-        <flux:card class="flex flex-col gap-4">
+        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
             <div class="flex items-center justify-between">
-                <flux:heading>{{ __('Low Stock Alerts') }}</flux:heading>
+                <div class="flex items-center gap-2">
+                    <flux:icon.exclamation-triangle class="size-5 text-red-500" />
+                    <flux:heading>{{ __('Low Stock Alerts') }}</flux:heading>
+                </div>
                 @if($this->lowStockProducts->isNotEmpty())
                     <flux:badge variant="danger">{{ $this->lowStockProducts->count() }}</flux:badge>
                 @endif
             </div>
 
             @if($this->lowStockProducts->isEmpty())
-                <div class="flex flex-1 flex-col items-center justify-center py-8 text-center">
-                    <flux:icon.check-circle class="mb-2 size-8 text-green-500" />
+                <div class="flex flex-1 flex-col items-center justify-center py-10 text-center">
+                    <div class="mb-3 rounded-full bg-green-50 p-3 dark:bg-green-900/20">
+                        <flux:icon.check-circle class="size-8 text-green-500" />
+                    </div>
                     <flux:text class="text-zinc-500">{{ __('All products are sufficiently stocked.') }}</flux:text>
                 </div>
             @else
                 <div class="flex flex-col gap-2">
                     @foreach($this->lowStockProducts as $product)
-                        <div class="flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/40 dark:bg-red-900/10">
-                            <div>
-                                <flux:text class="font-medium text-zinc-800 dark:text-zinc-100">{{ $product->name }}</flux:text>
-                                <flux:text class="text-xs text-zinc-500">{{ $product->category->name }} · SKU: {{ $product->sku }}</flux:text>
+                        <div class="flex items-center justify-between rounded-lg border border-red-100 bg-red-50 px-4 py-3 dark:border-red-900/30 dark:bg-red-900/10">
+                            <div class="min-w-0">
+                                <p class="truncate font-medium text-zinc-900 dark:text-zinc-100">{{ $product->name }}</p>
+                                <p class="text-xs text-zinc-400">{{ $product->category->name }} · {{ $product->sku }}</p>
                             </div>
-                            <div class="text-end">
-                                <flux:badge variant="danger">{{ $product->totalStock() }} / {{ $product->min_stock }}</flux:badge>
-                                <flux:text class="mt-0.5 text-xs text-zinc-400">{{ __('stock / min') }}</flux:text>
+                            <div class="ml-3 shrink-0 text-end">
+                                <span class="text-lg font-bold text-red-600 dark:text-red-400">{{ $product->totalStock() }}</span>
+                                <span class="text-sm text-zinc-400"> / {{ $product->min_stock }}</span>
+                                <p class="text-xs text-zinc-400">{{ __('stock / min') }}</p>
                             </div>
                         </div>
                     @endforeach
                 </div>
+                @if($isAdmin)
+                    <flux:button :href="route('stock.movements.create')" wire:navigate variant="filled" size="sm" icon="plus" class="mt-1 self-start">
+                        {{ __('Register Incoming') }}
+                    </flux:button>
+                @endif
             @endif
-        </flux:card>
+        </div>
 
         {{-- Recent Activity --}}
-        <flux:card class="flex flex-col gap-4">
-            <flux:heading>{{ __('Recent Activity') }}</flux:heading>
+        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="flex items-center gap-2">
+                <flux:icon.clock class="size-5 text-zinc-400" />
+                <flux:heading>{{ __('Recent Activity') }}</flux:heading>
+            </div>
 
             @if($this->recentActivity->isEmpty())
-                <div class="flex flex-1 flex-col items-center justify-center py-8 text-center">
-                    <flux:icon.clock class="mb-2 size-8 text-zinc-400" />
+                <div class="flex flex-1 flex-col items-center justify-center py-10 text-center">
+                    <div class="mb-3 rounded-full bg-zinc-50 p-3 dark:bg-zinc-800">
+                        <flux:icon.clock class="size-8 text-zinc-400" />
+                    </div>
                     <flux:text class="text-zinc-500">{{ __('No activity yet.') }}</flux:text>
                 </div>
             @else
-                <div class="flex flex-col gap-2">
+                <div class="flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800">
                     @foreach($this->recentActivity as $activity)
-                        <div class="flex items-start gap-3">
+                        <div class="flex items-start gap-3 py-3 first:pt-0 last:pb-0">
                             <flux:avatar
                                 size="sm"
                                 :name="$activity->causer?->name ?? 'System'"
-                                :initials="$activity->causer?->initials() ?? 'SY'"
                                 class="mt-0.5 shrink-0"
                             />
                             <div class="min-w-0 flex-1">
-                                <flux:text class="text-sm">
-                                    <span class="font-medium">{{ $activity->causer?->name ?? __('System') }}</span>
-                                    {{ $activity->description }}
-                                    <span class="font-medium">{{ class_basename($activity->subject_type ?? '') }}</span>
-                                </flux:text>
-                                <flux:text class="text-xs text-zinc-400">{{ $activity->created_at->diffForHumans() }}</flux:text>
+                                <p class="text-sm text-zinc-700 dark:text-zinc-300">
+                                    <span class="font-semibold">{{ $activity->causer?->name ?? __('System') }}</span>
+                                    <span class="text-zinc-500"> {{ $activity->description }} </span>
+                                    <span class="font-medium text-zinc-600 dark:text-zinc-400">{{ class_basename($activity->subject_type ?? '') }}</span>
+                                </p>
+                                <p class="text-xs text-zinc-400">{{ $activity->created_at->diffForHumans() }}</p>
                             </div>
                         </div>
                     @endforeach
                 </div>
             @endif
-        </flux:card>
+        </div>
 
     </div>
 

--- a/resources/views/livewire/deliveries/index.blade.php
+++ b/resources/views/livewire/deliveries/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Deliveries') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Deliveries') }}</flux:heading>
+            <flux:subheading>{{ __('Incoming deliveries and their processing status') }}</flux:subheading>
+        </div>
         @if(auth()->user()->isAdmin())
             <flux:button :href="route('deliveries.create')" wire:navigate variant="primary" icon="plus">
                 {{ __('New Delivery') }}
@@ -78,8 +81,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="7" class="py-12 text-center">
-                        {{ $filterStatus ? __('No deliveries with this status.') : __('No deliveries yet.') }}
+                    <flux:table.cell colspan="7" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.inbox-arrow-down class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $filterStatus ? __('No deliveries with this status.') : __('No deliveries yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/deliveries/show.blade.php
+++ b/resources/views/livewire/deliveries/show.blade.php
@@ -1,36 +1,78 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
-    {{-- Header --}}
-    <div class="flex items-center gap-4">
-        <flux:button :href="route('deliveries.index')" wire:navigate variant="ghost" icon="arrow-left" />
-        <div>
-            <flux:heading size="xl">
-                {{ __('Delivery') }} {{ $delivery->reference ? "— {$delivery->reference}" : "#{$delivery->id}" }}
-            </flux:heading>
-            <flux:subheading>{{ $delivery->supplier->name }} · {{ $delivery->created_at->format('d/m/Y') }}</flux:subheading>
+    {{-- Back + Header --}}
+    <div>
+        <flux:button :href="route('deliveries.index')" wire:navigate variant="ghost" icon="arrow-left" size="sm" class="mb-4">
+            {{ __('All Deliveries') }}
+        </flux:button>
+
+        <div class="flex flex-wrap items-start justify-between gap-4">
+            <div class="flex items-center gap-4">
+                @php
+                    $statusVariant = match($delivery->status->value) {
+                        'received' => 'success',
+                        'partial'  => 'warning',
+                        default    => 'outline',
+                    };
+                    $statusIcon = match($delivery->status->value) {
+                        'received' => 'check-circle',
+                        'partial'  => 'clock',
+                        default    => 'inbox',
+                    };
+                @endphp
+                <div class="rounded-xl bg-zinc-100 p-3 dark:bg-zinc-800">
+                    <flux:icon.inbox-arrow-down class="size-7 text-zinc-600 dark:text-zinc-300" />
+                </div>
+                <div>
+                    <div class="flex items-center gap-2">
+                        <flux:heading size="xl">
+                            {{ $delivery->reference ?? __('Delivery') . ' #' . $delivery->id }}
+                        </flux:heading>
+                        <flux:badge variant="{{ $statusVariant }}" icon="{{ $statusIcon }}">{{ ucfirst($delivery->status->value) }}</flux:badge>
+                    </div>
+                    <p class="mt-0.5 text-sm text-zinc-500">
+                        <span class="font-medium">{{ $delivery->supplier->name }}</span>
+                        <span class="mx-1.5 text-zinc-300 dark:text-zinc-600">·</span>
+                        {{ $delivery->created_at->format('d/m/Y') }}
+                        <span class="mx-1.5 text-zinc-300 dark:text-zinc-600">·</span>
+                        {{ __('Created by') }} {{ $delivery->user->name }}
+                    </p>
+                </div>
+            </div>
+
+            {{-- Progress summary --}}
+            @php
+                $totalOrdered  = $delivery->items->sum('quantity_ordered');
+                $totalReceived = $delivery->items->sum('quantity_received');
+                $pct = $totalOrdered > 0 ? round(($totalReceived / $totalOrdered) * 100) : 0;
+            @endphp
+            <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-5 py-3 dark:border-zinc-700 dark:bg-zinc-900">
+                <div>
+                    <p class="text-right text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $pct }}%</p>
+                    <p class="text-xs text-zinc-500">{{ __('received') }}</p>
+                </div>
+                <div class="h-10 w-px bg-zinc-200 dark:bg-zinc-700"></div>
+                <div class="text-sm">
+                    <p><span class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $totalReceived }}</span> <span class="text-zinc-500">/ {{ $totalOrdered }}</span></p>
+                    <p class="text-zinc-500">{{ __('units') }}</p>
+                </div>
+            </div>
         </div>
-        @php
-            $statusVariant = match($delivery->status->value) {
-                'received' => 'success',
-                'partial' => 'warning',
-                default => 'outline',
-            };
-        @endphp
-        <flux:badge variant="{{ $statusVariant }}" class="ml-2">{{ ucfirst($delivery->status->value) }}</flux:badge>
     </div>
 
-    <div class="flex max-w-3xl flex-col gap-6">
+    <div class="flex max-w-4xl flex-col gap-6">
 
-        {{-- Meta --}}
+        {{-- Notes --}}
         @if($delivery->notes)
-            <flux:card>
-                <flux:text class="text-sm text-zinc-500">{{ $delivery->notes }}</flux:text>
-            </flux:card>
+            <div class="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/40 dark:bg-amber-900/10">
+                <flux:icon.information-circle class="mt-0.5 size-5 shrink-0 text-amber-600 dark:text-amber-400" />
+                <p class="text-sm text-amber-800 dark:text-amber-300">{{ $delivery->notes }}</p>
+            </div>
         @endif
 
-        {{-- Items --}}
+        {{-- Items table --}}
         <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
-            <flux:heading size="lg">{{ __('Items') }}</flux:heading>
+            <flux:heading size="lg">{{ __('Delivery Items') }}</flux:heading>
 
             <flux:table>
                 <flux:table.columns>
@@ -45,29 +87,34 @@
 
                 <flux:table.rows>
                     @foreach ($delivery->items as $item)
+                        @php $remaining = $item->quantity_ordered - $item->quantity_received; @endphp
                         <flux:table.row :key="$item->id">
                             <flux:table.cell variant="strong">
                                 {{ $item->product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $item->product->sku }}</div>
+                                <div class="text-xs font-mono font-normal text-zinc-400">{{ $item->product->sku }}</div>
                             </flux:table.cell>
 
                             <flux:table.cell class="text-sm">
-                                {{ $item->location->warehouse->name }} — {{ $item->location->code }}
+                                <div class="flex items-center gap-1.5">
+                                    <flux:icon.building-office class="size-3.5 text-zinc-400" />
+                                    <span class="text-zinc-500">{{ $item->location->warehouse->name }}</span>
+                                    <span class="text-zinc-300 dark:text-zinc-600">·</span>
+                                    <span class="font-mono font-medium">{{ $item->location->code }}</span>
+                                </div>
                             </flux:table.cell>
 
                             <flux:table.cell>
-                                {{ $item->quantity_ordered }}
+                                <span class="font-medium">{{ $item->quantity_ordered }}</span>
                             </flux:table.cell>
 
                             <flux:table.cell>
-                                <span class="{{ $item->quantity_received >= $item->quantity_ordered ? 'text-green-600 dark:text-green-400' : '' }} font-medium">
+                                <span class="font-semibold {{ $item->quantity_received >= $item->quantity_ordered ? 'text-emerald-600 dark:text-emerald-400' : '' }}">
                                     {{ $item->quantity_received }}
                                 </span>
                             </flux:table.cell>
 
                             @if($delivery->status !== \App\Enums\DeliveryStatus::Received)
                                 <flux:table.cell>
-                                    @php $remaining = $item->quantity_ordered - $item->quantity_received; @endphp
                                     @if($remaining > 0)
                                         <flux:input
                                             wire:model="receivedQuantities.{{ $item->id }}"
@@ -77,7 +124,7 @@
                                             class="w-24"
                                         />
                                     @else
-                                        <flux:badge variant="success">{{ __('Done') }}</flux:badge>
+                                        <flux:badge variant="success" icon="check">{{ __('Done') }}</flux:badge>
                                     @endif
                                 </flux:table.cell>
                             @endif
@@ -87,7 +134,7 @@
             </flux:table>
 
             @if($delivery->status !== \App\Enums\DeliveryStatus::Received)
-                <div class="flex justify-end">
+                <div class="flex justify-end pt-2">
                     <flux:button
                         wire:click="process"
                         wire:confirm="{{ __('Process this delivery and update stock?') }}"
@@ -98,10 +145,10 @@
                     </flux:button>
                 </div>
             @else
-                <flux:text class="text-sm text-zinc-400">
+                <p class="text-sm text-zinc-400">
                     {{ __('Fully received on') }} {{ $delivery->received_at?->format('d/m/Y H:i') }}
                     {{ __('by') }} {{ $delivery->user->name }}.
-                </flux:text>
+                </p>
             @endif
         </div>
 

--- a/resources/views/livewire/locations/index.blade.php
+++ b/resources/views/livewire/locations/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Locations') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Locations') }}</flux:heading>
+            <flux:subheading>{{ __('Storage positions within your warehouses') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Location') }}
         </flux:button>
@@ -42,7 +45,7 @@
             @forelse ($this->locations as $location)
                 <flux:table.row :key="$location->id">
                     <flux:table.cell variant="strong">
-                        <flux:badge>{{ $location->code }}</flux:badge>
+                        <span class="rounded-md bg-zinc-100 px-2.5 py-1 font-mono text-sm font-semibold text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">{{ $location->code }}</span>
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -86,8 +89,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
-                        {{ $search || $filterWarehouse ? __('No locations match your filters.') : __('No locations yet.') }}
+                    <flux:table.cell colspan="6" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.map-pin class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $search || $filterWarehouse ? __('No locations match your filters.') : __('No locations yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Products') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Products') }}</flux:heading>
+            <flux:subheading>{{ __('Manage your product catalogue, SKUs and categories') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Product') }}
         </flux:button>

--- a/resources/views/livewire/reports/index.blade.php
+++ b/resources/views/livewire/reports/index.blade.php
@@ -1,29 +1,35 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
     {{-- Header --}}
-    <flux:heading size="xl">{{ __('Reports') }}</flux:heading>
+    <div>
+        <flux:heading size="xl">{{ __('Reports') }}</flux:heading>
+        <flux:subheading>{{ __('Insights into stock levels, locations and movement history') }}</flux:subheading>
+    </div>
 
     {{-- Tabs --}}
     <div class="flex gap-1 border-b border-zinc-200 dark:border-zinc-700">
         <button
             wire:click="setTab('low-stock')"
-            class="px-4 py-2 text-sm font-medium transition {{ $tab === 'low-stock' ? 'border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
+            class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'low-stock' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
         >
+            <flux:icon.exclamation-triangle class="size-4" />
             {{ __('Low Stock') }}
-            @if($tab === 'low-stock' && $this->lowStockProducts->isNotEmpty())
-                <flux:badge variant="danger" size="sm" class="ml-1">{{ $this->lowStockProducts->count() }}</flux:badge>
+            @if($this->lowStockProducts->isNotEmpty())
+                <flux:badge variant="danger" size="sm">{{ $this->lowStockProducts->count() }}</flux:badge>
             @endif
         </button>
         <button
             wire:click="setTab('stock-per-location')"
-            class="px-4 py-2 text-sm font-medium transition {{ $tab === 'stock-per-location' ? 'border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
+            class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'stock-per-location' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
         >
+            <flux:icon.map-pin class="size-4" />
             {{ __('Stock per Location') }}
         </button>
         <button
             wire:click="setTab('movements')"
-            class="px-4 py-2 text-sm font-medium transition {{ $tab === 'movements' ? 'border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
+            class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'movements' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
         >
+            <flux:icon.arrow-path class="size-4" />
             {{ __('Movements per Period') }}
         </button>
     </div>
@@ -31,43 +37,39 @@
     {{-- TAB: Low Stock --}}
     @if($tab === 'low-stock')
         @if($this->lowStockProducts->isEmpty())
-            <div class="flex flex-1 flex-col items-center justify-center py-16 text-center">
-                <flux:icon.check-circle class="mb-3 size-10 text-green-500" />
+            <div class="flex flex-1 flex-col items-center justify-center py-20 text-center">
+                <div class="mb-3 rounded-full bg-green-50 p-4 dark:bg-green-900/20">
+                    <flux:icon.check-circle class="size-10 text-green-500" />
+                </div>
                 <flux:heading>{{ __('All products are sufficiently stocked.') }}</flux:heading>
                 <flux:text class="text-zinc-400">{{ __('No products are currently below their minimum stock level.') }}</flux:text>
             </div>
         @else
-            <flux:table>
-                <flux:table.columns>
-                    <flux:table.column>{{ __('Product') }}</flux:table.column>
-                    <flux:table.column>{{ __('Category') }}</flux:table.column>
-                    <flux:table.column>{{ __('Current Stock') }}</flux:table.column>
-                    <flux:table.column>{{ __('Minimum') }}</flux:table.column>
-                    <flux:table.column>{{ __('Shortage') }}</flux:table.column>
-                    <flux:table.column>{{ __('Locations') }}</flux:table.column>
-                </flux:table.columns>
-                <flux:table.rows>
-                    @foreach($this->lowStockProducts as $product)
-                        <flux:table.row :key="$product->id">
-                            <flux:table.cell variant="strong">
-                                {{ $product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $product->sku }}</div>
-                            </flux:table.cell>
-                            <flux:table.cell>{{ $product->category?->name ?? '—' }}</flux:table.cell>
-                            <flux:table.cell>
-                                <span class="font-medium text-red-600 dark:text-red-400">{{ $product->totalStock() }}</span>
-                            </flux:table.cell>
-                            <flux:table.cell>{{ $product->min_stock }}</flux:table.cell>
-                            <flux:table.cell>
-                                <flux:badge variant="danger">{{ $product->totalStock() - $product->min_stock }}</flux:badge>
-                            </flux:table.cell>
-                            <flux:table.cell class="text-sm text-zinc-500">
-                                {{ $product->stock->map(fn($s) => $s->location->code)->join(', ') ?: '—' }}
-                            </flux:table.cell>
-                        </flux:table.row>
-                    @endforeach
-                </flux:table.rows>
-            </flux:table>
+            <div class="flex flex-col gap-3">
+                @foreach($this->lowStockProducts as $product)
+                    <div class="flex items-center justify-between rounded-xl border border-red-200 bg-red-50 px-5 py-4 dark:border-red-900/40 dark:bg-red-900/10">
+                        <div class="flex items-center gap-4">
+                            <div class="rounded-lg bg-red-100 p-2 dark:bg-red-900/30">
+                                <flux:icon.exclamation-triangle class="size-5 text-red-600 dark:text-red-400" />
+                            </div>
+                            <div>
+                                <p class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $product->name }}</p>
+                                <p class="text-xs text-zinc-500">{{ $product->category?->name ?? '—' }} · <span class="font-mono">{{ $product->sku }}</span></p>
+                                @if($product->stock->isNotEmpty())
+                                    <p class="mt-0.5 text-xs text-zinc-400">
+                                        {{ __('Locations:') }} {{ $product->stock->map(fn($s) => $s->location->code)->join(', ') }}
+                                    </p>
+                                @endif
+                            </div>
+                        </div>
+                        <div class="text-right">
+                            <p class="text-2xl font-bold text-red-600 dark:text-red-400">{{ $product->totalStock() }}<span class="text-sm font-normal text-zinc-400"> / {{ $product->min_stock }}</span></p>
+                            <p class="text-xs text-zinc-500">{{ __('stock / minimum') }}</p>
+                            <flux:badge variant="danger" class="mt-1">{{ __('shortage:') }} {{ $product->totalStock() - $product->min_stock }}</flux:badge>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
         @endif
     @endif
 
@@ -82,13 +84,14 @@
                     @endforeach
                 </flux:select>
             </div>
-            <flux:text class="text-sm text-zinc-400">
-                {{ $this->stockPerLocation->count() }} {{ __('lines') }}
-            </flux:text>
+            <span class="text-sm text-zinc-400">{{ $this->stockPerLocation->count() }} {{ __('lines') }}</span>
         </div>
 
         @if($this->stockPerLocation->isEmpty())
-            <flux:text class="py-12 text-center text-zinc-400">{{ __('No stock registered yet.') }}</flux:text>
+            <div class="flex flex-col items-center justify-center py-16 text-center">
+                <flux:icon.cube class="mb-2 size-10 text-zinc-300" />
+                <flux:text class="text-zinc-400">{{ __('No stock registered yet.') }}</flux:text>
+            </div>
         @else
             <flux:table>
                 <flux:table.columns>
@@ -101,17 +104,22 @@
                 <flux:table.rows>
                     @foreach($this->stockPerLocation as $line)
                         <flux:table.row :key="$line->id">
-                            <flux:table.cell>{{ $line->location->warehouse->name }}</flux:table.cell>
                             <flux:table.cell>
-                                <flux:badge>{{ $line->location->code }}</flux:badge>
+                                <div class="flex items-center gap-1.5 text-sm">
+                                    <flux:icon.building-office class="size-4 text-zinc-400" />
+                                    {{ $line->location->warehouse->name }}
+                                </div>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <span class="rounded bg-zinc-100 px-2 py-0.5 font-mono text-xs font-semibold dark:bg-zinc-800">{{ $line->location->code }}</span>
                             </flux:table.cell>
                             <flux:table.cell variant="strong">
                                 {{ $line->product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $line->product->sku }}</div>
+                                <div class="font-mono text-xs font-normal text-zinc-400">{{ $line->product->sku }}</div>
                             </flux:table.cell>
                             <flux:table.cell>{{ $line->product->category?->name ?? '—' }}</flux:table.cell>
                             <flux:table.cell>
-                                <span class="font-medium">{{ $line->quantity }}</span>
+                                <span class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $line->quantity }}</span>
                             </flux:table.cell>
                         </flux:table.row>
                     @endforeach
@@ -122,7 +130,7 @@
 
     {{-- TAB: Movements per Period --}}
     @if($tab === 'movements')
-        <div class="flex flex-wrap items-center gap-3">
+        <div class="flex flex-wrap items-end gap-3">
             <flux:field>
                 <flux:label>{{ __('From') }}</flux:label>
                 <flux:input wire:model.live="filterFrom" type="date" />
@@ -140,13 +148,14 @@
                     @endforeach
                 </flux:select>
             </flux:field>
-            <flux:text class="mt-5 text-sm text-zinc-400">
-                {{ $this->movements->count() }} {{ __('movements') }}
-            </flux:text>
+            <p class="mb-2 text-sm text-zinc-400">{{ $this->movements->count() }} {{ __('movements') }}</p>
         </div>
 
         @if($this->movements->isEmpty())
-            <flux:text class="py-12 text-center text-zinc-400">{{ __('No movements found for this period.') }}</flux:text>
+            <div class="flex flex-col items-center justify-center py-16 text-center">
+                <flux:icon.arrow-path class="mb-2 size-10 text-zinc-300" />
+                <flux:text class="text-zinc-400">{{ __('No movements found for this period.') }}</flux:text>
+            </div>
         @else
             <flux:table>
                 <flux:table.columns>
@@ -163,18 +172,20 @@
                         <flux:table.row :key="$movement->id">
                             <flux:table.cell variant="strong">
                                 {{ $movement->product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $movement->product->sku }}</div>
+                                <div class="font-mono text-xs font-normal text-zinc-400">{{ $movement->product->sku }}</div>
                             </flux:table.cell>
                             <flux:table.cell>
                                 @php
-                                    $v = match($movement->type->value) {
-                                        'incoming' => 'success', 'outgoing' => 'danger',
-                                        'transfer' => 'warning', default => 'outline',
+                                    [$v, $ico] = match($movement->type->value) {
+                                        'incoming'   => ['success', 'arrow-down-tray'],
+                                        'outgoing'   => ['danger', 'arrow-up-tray'],
+                                        'transfer'   => ['warning', 'arrows-right-left'],
+                                        default      => ['outline', 'pencil-square'],
                                     };
                                 @endphp
-                                <flux:badge variant="{{ $v }}">{{ ucfirst($movement->type->value) }}</flux:badge>
+                                <flux:badge variant="{{ $v }}" icon="{{ $ico }}">{{ ucfirst($movement->type->value) }}</flux:badge>
                             </flux:table.cell>
-                            <flux:table.cell class="text-sm">
+                            <flux:table.cell class="font-mono text-sm">
                                 @if($movement->type->value === 'transfer')
                                     {{ $movement->fromLocation?->code }} → {{ $movement->toLocation?->code }}
                                 @else
@@ -182,7 +193,7 @@
                                 @endif
                             </flux:table.cell>
                             <flux:table.cell>
-                                <span class="{{ $movement->quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }} font-medium">
+                                <span class="font-bold {{ $movement->quantity > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400' }}">
                                     {{ $movement->quantity > 0 ? '+' : '' }}{{ $movement->quantity }}
                                 </span>
                             </flux:table.cell>

--- a/resources/views/livewire/stock/index.blade.php
+++ b/resources/views/livewire/stock/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Stock Overview') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Stock Overview') }}</flux:heading>
+            <flux:subheading>{{ __('Current stock levels per product and location') }}</flux:subheading>
+        </div>
         <flux:button :href="route('stock.movements.create')" wire:navigate variant="primary" icon="plus">
             {{ __('Register Movement') }}
         </flux:button>
@@ -30,6 +33,7 @@
     {{-- Table --}}
     <flux:table>
         <flux:table.columns>
+            <flux:table.column></flux:table.column>
             <flux:table.column>{{ __('Product') }}</flux:table.column>
             <flux:table.column>{{ __('SKU') }}</flux:table.column>
             <flux:table.column>{{ __('Category') }}</flux:table.column>
@@ -40,39 +44,98 @@
 
         <flux:table.rows>
             @forelse ($this->stockLines as $product)
+                @php
+                    $totalQty   = $product->stock->sum('quantity');
+                    $belowMin   = $product->min_stock > 0 && $totalQty < $product->min_stock;
+                    $rowClass   = $belowMin ? 'bg-red-50/60 dark:bg-red-900/5' : '';
+                @endphp
+
                 @if ($product->stock->isEmpty())
-                    <flux:table.row :key="'p-'.$product->id">
+                    <flux:table.row :key="'p-'.$product->id" class="{{ $rowClass }}">
+                        {{-- Image --}}
+                        <flux:table.cell>
+                            @if ($product->image_path)
+                                <img src="{{ Storage::url($product->image_path) }}" alt="{{ $product->name }}" class="size-9 rounded-lg object-cover" />
+                            @else
+                                <div class="flex size-9 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800">
+                                    <flux:icon.photo class="size-4 text-zinc-400" />
+                                </div>
+                            @endif
+                        </flux:table.cell>
                         <flux:table.cell variant="strong">{{ $product->name }}</flux:table.cell>
                         <flux:table.cell><flux:badge>{{ $product->sku }}</flux:badge></flux:table.cell>
                         <flux:table.cell>{{ $product->category?->name ?? '—' }}</flux:table.cell>
-                        <flux:table.cell class="text-zinc-400">{{ __('No stock registered') }}</flux:table.cell>
-                        <flux:table.cell>0</flux:table.cell>
+                        <flux:table.cell class="text-zinc-400 italic">{{ __('No stock registered') }}</flux:table.cell>
+                        <flux:table.cell>
+                            <span class="font-bold text-zinc-400">0</span>
+                        </flux:table.cell>
                         <flux:table.cell>
                             @if($product->min_stock > 0)
-                                <flux:badge variant="danger">{{ __('Below minimum') }}</flux:badge>
+                                <flux:badge variant="danger" icon="exclamation-triangle">{{ __('Below minimum') }}</flux:badge>
+                            @else
+                                <flux:badge variant="outline">{{ __('No minimum') }}</flux:badge>
                             @endif
                         </flux:table.cell>
                     </flux:table.row>
                 @else
-                    @foreach ($product->stock as $stockLine)
-                        <flux:table.row :key="'s-'.$stockLine->id">
-                            <flux:table.cell variant="strong">{{ $product->name }}</flux:table.cell>
-                            <flux:table.cell><flux:badge>{{ $product->sku }}</flux:badge></flux:table.cell>
-                            <flux:table.cell>{{ $product->category?->name ?? '—' }}</flux:table.cell>
+                    @foreach ($product->stock as $i => $stockLine)
+                        <flux:table.row :key="'s-'.$stockLine->id" class="{{ $rowClass }}">
+                            {{-- Image only on first row --}}
                             <flux:table.cell>
-                                <span class="text-sm">
-                                    {{ $stockLine->location->warehouse->name }} —
-                                    <span class="font-medium">{{ $stockLine->location->code }}</span>
+                                @if ($i === 0)
+                                    @if ($product->image_path)
+                                        <img src="{{ Storage::url($product->image_path) }}" alt="{{ $product->name }}" class="size-9 rounded-lg object-cover" />
+                                    @else
+                                        <div class="flex size-9 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800">
+                                            <flux:icon.photo class="size-4 text-zinc-400" />
+                                        </div>
+                                    @endif
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell variant="strong">
+                                @if ($i === 0)
+                                    {{ $product->name }}
+                                    @if ($product->stock->count() > 1)
+                                        <span class="ml-1 text-xs font-normal text-zinc-400">({{ $product->stock->count() }} {{ __('locations') }})</span>
+                                    @endif
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                @if ($i === 0)
+                                    <flux:badge>{{ $product->sku }}</flux:badge>
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                @if ($i === 0)
+                                    {{ $product->category?->name ?? '—' }}
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                <div class="flex items-center gap-1.5 text-sm">
+                                    <flux:icon.building-office class="size-3.5 text-zinc-400" />
+                                    <span class="text-zinc-500">{{ $stockLine->location->warehouse->name }}</span>
+                                    <span class="text-zinc-300 dark:text-zinc-600">·</span>
+                                    <span class="font-medium font-mono">{{ $stockLine->location->code }}</span>
+                                </div>
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                <span class="text-lg font-bold {{ $belowMin && $i === 0 ? 'text-red-600 dark:text-red-400' : 'text-zinc-900 dark:text-zinc-100' }}">
+                                    {{ $stockLine->quantity }}
                                 </span>
                             </flux:table.cell>
+
                             <flux:table.cell>
-                                <span class="font-medium">{{ $stockLine->quantity }}</span>
-                            </flux:table.cell>
-                            <flux:table.cell>
-                                @if ($product->min_stock > 0 && $product->totalStock() < $product->min_stock)
-                                    <flux:badge variant="danger">{{ __('Below minimum') }}</flux:badge>
-                                @else
-                                    <flux:badge variant="success">{{ __('OK') }}</flux:badge>
+                                @if ($i === 0)
+                                    @if ($belowMin)
+                                        <flux:badge variant="danger" icon="exclamation-triangle">{{ __('Below minimum') }}</flux:badge>
+                                    @else
+                                        <flux:badge variant="success" icon="check">{{ __('OK') }}</flux:badge>
+                                    @endif
                                 @endif
                             </flux:table.cell>
                         </flux:table.row>
@@ -80,8 +143,13 @@
                 @endif
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
-                        {{ $search || $filterWarehouse ? __('No products match your filters.') : __('No products found.') }}
+                    <flux:table.cell colspan="7" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.cube class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">
+                                {{ $search || $filterWarehouse ? __('No products match your filters.') : __('No products found.') }}
+                            </span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/stock/movements.blade.php
+++ b/resources/views/livewire/stock/movements.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Stock Movements') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Stock Movements') }}</flux:heading>
+            <flux:subheading>{{ __('Full history of all incoming, outgoing, transfer and correction events') }}</flux:subheading>
+        </div>
         <flux:button :href="route('stock.movements.create')" wire:navigate variant="primary" icon="plus">
             {{ __('Register Movement') }}
         </flux:button>
@@ -44,33 +47,43 @@
                 <flux:table.row :key="$movement->id">
                     <flux:table.cell variant="strong">
                         {{ $movement->product->name }}
-                        <div class="text-xs font-normal text-zinc-400">{{ $movement->product->sku }}</div>
+                        <div class="text-xs font-mono font-normal text-zinc-400">{{ $movement->product->sku }}</div>
                     </flux:table.cell>
 
                     <flux:table.cell>
                         @php
-                            $typeVariant = match($movement->type->value) {
-                                'incoming' => 'success',
-                                'outgoing' => 'danger',
-                                'transfer' => 'warning',
-                                'correction' => 'outline',
-                                default => 'outline',
+                            [$variant, $icon] = match($movement->type->value) {
+                                'incoming'   => ['success', 'arrow-down-tray'],
+                                'outgoing'   => ['danger', 'arrow-up-tray'],
+                                'transfer'   => ['warning', 'arrows-right-left'],
+                                'correction' => ['outline', 'pencil-square'],
+                                default      => ['outline', 'question-mark-circle'],
                             };
                         @endphp
-                        <flux:badge variant="{{ $typeVariant }}">{{ ucfirst($movement->type->value) }}</flux:badge>
+                        <flux:badge variant="{{ $variant }}" icon="{{ $icon }}">{{ ucfirst($movement->type->value) }}</flux:badge>
                     </flux:table.cell>
 
                     <flux:table.cell class="text-sm">
                         @if ($movement->type->value === 'transfer')
-                            <span class="text-zinc-500">{{ $movement->fromLocation?->code }}</span>
-                            → {{ $movement->toLocation?->code }}
+                            <span class="flex items-center gap-1">
+                                <span class="font-mono font-medium">{{ $movement->fromLocation?->code ?? '—' }}</span>
+                                <flux:icon.arrow-right class="size-3 text-zinc-400" />
+                                <span class="font-mono font-medium">{{ $movement->toLocation?->code ?? '—' }}</span>
+                            </span>
                         @else
-                            {{ $movement->location?->code ?? '—' }}
+                            <span class="font-mono font-medium">{{ $movement->location?->code ?? '—' }}</span>
                         @endif
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        <span class="{{ $movement->quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }} font-medium">
+                        @php
+                            $qtyClass = match(true) {
+                                $movement->quantity > 0  => 'text-emerald-600 dark:text-emerald-400',
+                                $movement->quantity < 0  => 'text-red-600 dark:text-red-400',
+                                default                  => 'text-zinc-500',
+                            };
+                        @endphp
+                        <span class="text-base font-bold {{ $qtyClass }}">
                             {{ $movement->quantity > 0 ? '+' : '' }}{{ $movement->quantity }}
                         </span>
                     </flux:table.cell>
@@ -79,18 +92,28 @@
                         {{ $movement->reference ?? '—' }}
                     </flux:table.cell>
 
-                    <flux:table.cell class="text-sm">
-                        {{ $movement->user->name }}
+                    <flux:table.cell>
+                        <div class="flex items-center gap-2">
+                            <flux:avatar size="xs" :name="$movement->user->name" />
+                            <span class="text-sm">{{ $movement->user->name }}</span>
+                        </div>
                     </flux:table.cell>
 
                     <flux:table.cell class="text-sm text-zinc-400">
-                        {{ $movement->created_at->diffForHumans() }}
+                        <span title="{{ $movement->created_at->format('d/m/Y H:i') }}">
+                            {{ $movement->created_at->diffForHumans() }}
+                        </span>
                     </flux:table.cell>
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="7" class="py-12 text-center">
-                        {{ $search || $filterType ? __('No movements match your filters.') : __('No stock movements yet.') }}
+                    <flux:table.cell colspan="7" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.arrow-path class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">
+                                {{ $search || $filterType ? __('No movements match your filters.') : __('No stock movements yet.') }}
+                            </span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/suppliers/index.blade.php
+++ b/resources/views/livewire/suppliers/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Suppliers') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Suppliers') }}</flux:heading>
+            <flux:subheading>{{ __('Manage your product suppliers and their contact information') }}</flux:subheading>
+        </div>
         @if(auth()->user()->isAdmin())
             <flux:button wire:click="openCreate" variant="primary" icon="plus">
                 {{ __('New Supplier') }}
@@ -35,11 +38,18 @@
             @forelse ($this->suppliers as $supplier)
                 <flux:table.row :key="$supplier->id">
                     <flux:table.cell variant="strong">
-                        {{ $supplier->name }}
+                        <div class="flex items-center gap-3">
+                            <flux:avatar size="sm" :name="$supplier->name" />
+                            <span>{{ $supplier->name }}</span>
+                        </div>
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        {{ $supplier->email ?? '—' }}
+                        @if($supplier->email)
+                            <a href="mailto:{{ $supplier->email }}" class="text-blue-600 hover:underline dark:text-blue-400">{{ $supplier->email }}</a>
+                        @else
+                            <span class="text-zinc-400">—</span>
+                        @endif
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -77,8 +87,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="5" class="py-12 text-center">
-                        {{ $search ? __('No suppliers match your search.') : __('No suppliers yet.') }}
+                    <flux:table.cell colspan="5" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.building-storefront class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $search ? __('No suppliers match your search.') : __('No suppliers yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/warehouses/index.blade.php
+++ b/resources/views/livewire/warehouses/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Warehouses') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Warehouses') }}</flux:heading>
+            <flux:subheading>{{ __('Manage your warehouse locations and storage capacity') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Warehouse') }}
         </flux:button>
@@ -17,84 +20,101 @@
         />
     </div>
 
-    {{-- Table --}}
-    <flux:table>
-        <flux:table.columns>
-            <flux:table.column>{{ __('Name') }}</flux:table.column>
-            <flux:table.column>{{ __('Location') }}</flux:table.column>
-            <flux:table.column>{{ __('Description') }}</flux:table.column>
-            <flux:table.column>{{ __('Locations') }}</flux:table.column>
-            <flux:table.column>{{ __('Created') }}</flux:table.column>
-            <flux:table.column></flux:table.column>
-        </flux:table.columns>
+    {{-- Card Grid --}}
+    @if ($this->warehouses->isEmpty())
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 py-20 text-center dark:border-zinc-700">
+            <div class="mb-3 rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
+                <flux:icon.building-office class="size-8 text-zinc-400" />
+            </div>
+            <flux:heading size="lg" class="mb-1">{{ __('No warehouses yet') }}</flux:heading>
+            <flux:text class="mb-4 text-zinc-500">{{ $search ? __('No warehouses match your search.') : __('Create your first warehouse to get started.') }}</flux:text>
+            @unless($search)
+                <flux:button wire:click="openCreate" variant="primary" icon="plus" size="sm">{{ __('New Warehouse') }}</flux:button>
+            @endunless
+        </div>
+    @else
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ($this->warehouses as $warehouse)
+                <div class="group relative flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 transition duration-200 hover:border-blue-300 hover:shadow-lg dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-700">
 
-        <flux:table.rows>
-            @forelse ($this->warehouses as $warehouse)
-                <flux:table.row :key="$warehouse->id">
-                    <flux:table.cell variant="strong">
-                        {{ $warehouse->name }}
-                    </flux:table.cell>
+                    {{-- Top row --}}
+                    <div class="flex items-start justify-between">
+                        <div class="flex items-center gap-3">
+                            <div class="rounded-lg bg-blue-50 p-2.5 dark:bg-blue-900/30">
+                                <flux:icon.building-office class="size-5 text-blue-600 dark:text-blue-400" />
+                            </div>
+                            <div>
+                                <p class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $warehouse->name }}</p>
+                                <p class="flex items-center gap-1 text-xs text-zinc-500">
+                                    <flux:icon.map-pin class="size-3" />
+                                    {{ $warehouse->location }}
+                                </p>
+                            </div>
+                        </div>
 
-                    <flux:table.cell>
-                        {{ $warehouse->location }}
-                    </flux:table.cell>
+                        {{-- Actions (above the link overlay) --}}
+                        <div class="relative z-10">
+                            <flux:dropdown>
+                                <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
+                                <flux:menu>
+                                    <flux:menu.item icon="eye" :href="route('warehouses.show', $warehouse)" wire:navigate>
+                                        {{ __('View') }}
+                                    </flux:menu.item>
+                                    <flux:menu.item icon="pencil" wire:click="openEdit({{ $warehouse->id }})">
+                                        {{ __('Edit') }}
+                                    </flux:menu.item>
+                                    <flux:menu.separator />
+                                    <flux:menu.item
+                                        icon="trash"
+                                        variant="danger"
+                                        wire:click="delete({{ $warehouse->id }})"
+                                        wire:confirm="{{ __('Delete this warehouse?') }}"
+                                    >
+                                        {{ __('Delete') }}
+                                    </flux:menu.item>
+                                </flux:menu>
+                            </flux:dropdown>
+                        </div>
+                    </div>
 
-                    <flux:table.cell>
-                        {{ $warehouse->description ?? '—' }}
-                    </flux:table.cell>
+                    {{-- Description --}}
+                    @if ($warehouse->description)
+                        <p class="line-clamp-2 text-sm text-zinc-500">{{ $warehouse->description }}</p>
+                    @else
+                        <p class="text-sm italic text-zinc-400">{{ __('No description') }}</p>
+                    @endif
 
-                    <flux:table.cell>
-                        <flux:badge variant="outline">{{ $warehouse->locations_count }}</flux:badge>
-                    </flux:table.cell>
+                    {{-- Stats --}}
+                    <div class="flex items-center gap-4 border-t border-zinc-100 pt-4 dark:border-zinc-800">
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.map-pin class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $warehouse->locations_count }}</span>
+                            <span class="text-zinc-400">{{ __('locations') }}</span>
+                        </div>
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.cube class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $warehouse->total_stock }}</span>
+                            <span class="text-zinc-400">{{ __('items') }}</span>
+                        </div>
+                    </div>
 
-                    <flux:table.cell>
-                        {{ $warehouse->created_at->diffForHumans() }}
-                    </flux:table.cell>
+                    {{-- Clickable overlay (behind the dropdown) --}}
+                    <a href="{{ route('warehouses.show', $warehouse) }}" wire:navigate class="absolute inset-0 rounded-xl"></a>
+                </div>
+            @endforeach
+        </div>
 
-                    <flux:table.cell align="end">
-                        <flux:dropdown>
-                            <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
-                            <flux:menu>
-                                <flux:menu.item
-                                    icon="pencil"
-                                    wire:click="openEdit({{ $warehouse->id }})"
-                                >
-                                    {{ __('Edit') }}
-                                </flux:menu.item>
-                                <flux:menu.separator />
-                                <flux:menu.item
-                                    icon="trash"
-                                    variant="danger"
-                                    wire:click="delete({{ $warehouse->id }})"
-                                    wire:confirm="{{ __('Delete this warehouse?') }}"
-                                >
-                                    {{ __('Delete') }}
-                                </flux:menu.item>
-                            </flux:menu>
-                        </flux:dropdown>
-                    </flux:table.cell>
-                </flux:table.row>
-            @empty
-                <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
-                        {{ $search ? __('No warehouses match your search.') : __('No warehouses yet.') }}
-                    </flux:table.cell>
-                </flux:table.row>
-            @endforelse
-        </flux:table.rows>
-    </flux:table>
-
-    {{-- Pagination --}}
-    <div>
-        {{ $this->warehouses->links() }}
-    </div>
+        {{-- Pagination --}}
+        <div>{{ $this->warehouses->links() }}</div>
+    @endif
 
     {{-- Create / Edit Modal --}}
     <flux:modal wire:model="showModal" class="max-w-md">
         <div class="flex flex-col gap-6 p-6">
-            <flux:heading size="lg">
-                {{ $editingId ? __('Edit Warehouse') : __('New Warehouse') }}
-            </flux:heading>
+            <div>
+                <flux:heading size="lg">{{ $editingId ? __('Edit Warehouse') : __('New Warehouse') }}</flux:heading>
+                <flux:subheading>{{ $editingId ? __('Update warehouse details') : __('Add a new warehouse to your network') }}</flux:subheading>
+            </div>
 
             <flux:field>
                 <flux:label>{{ __('Name') }}</flux:label>
@@ -104,7 +124,7 @@
 
             <flux:field>
                 <flux:label>{{ __('Location') }}</flux:label>
-                <flux:input wire:model="location" placeholder="{{ __('e.g. Brussels') }}" />
+                <flux:input wire:model="location" placeholder="{{ __('e.g. Brussels') }}" icon="map-pin" />
                 <flux:error name="location" />
             </flux:field>
 
@@ -115,12 +135,8 @@
             </flux:field>
 
             <div class="flex justify-end gap-3">
-                <flux:button wire:click="$set('showModal', false)" variant="ghost">
-                    {{ __('Cancel') }}
-                </flux:button>
-                <flux:button wire:click="save" variant="primary">
-                    {{ $editingId ? __('Update') : __('Create') }}
-                </flux:button>
+                <flux:button wire:click="$set('showModal', false)" variant="ghost">{{ __('Cancel') }}</flux:button>
+                <flux:button wire:click="save" variant="primary">{{ $editingId ? __('Update') : __('Create') }}</flux:button>
             </div>
         </div>
     </flux:modal>

--- a/resources/views/livewire/warehouses/show.blade.php
+++ b/resources/views/livewire/warehouses/show.blade.php
@@ -1,0 +1,154 @@
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+
+    {{-- Back + Header --}}
+    <div>
+        <flux:button :href="route('warehouses.index')" wire:navigate variant="ghost" icon="arrow-left" size="sm" class="mb-4">
+            {{ __('All Warehouses') }}
+        </flux:button>
+
+        <div class="flex items-start justify-between">
+            <div class="flex items-center gap-4">
+                <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
+                    <flux:icon.building-office class="size-7 text-blue-600 dark:text-blue-400" />
+                </div>
+                <div>
+                    <flux:heading size="xl">{{ $warehouse->name }}</flux:heading>
+                    <div class="mt-0.5 flex items-center gap-1.5 text-sm text-zinc-500">
+                        <flux:icon.map-pin class="size-4" />
+                        {{ $warehouse->location }}
+                    </div>
+                </div>
+            </div>
+            <flux:button wire:click="openCreateLocation" variant="primary" icon="plus">
+                {{ __('New Location') }}
+            </flux:button>
+        </div>
+
+        @if ($warehouse->description)
+            <p class="mt-3 max-w-2xl text-sm text-zinc-500">{{ $warehouse->description }}</p>
+        @endif
+    </div>
+
+    {{-- Stats bar --}}
+    <div class="grid grid-cols-3 gap-4">
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
+                <flux:icon.map-pin class="size-5 text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+                <p class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['location_count'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Locations') }}</p>
+            </div>
+        </div>
+
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-emerald-50 p-2 dark:bg-emerald-900/30">
+                <flux:icon.cube class="size-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <div>
+                <p class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['total_stock'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Total items in stock') }}</p>
+            </div>
+        </div>
+
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <flux:icon.tag class="size-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+                <p class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['product_count'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Distinct products') }}</p>
+            </div>
+        </div>
+    </div>
+
+    {{-- Locations --}}
+    @if ($this->locations->isEmpty())
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 py-20 text-center dark:border-zinc-700">
+            <div class="mb-3 rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
+                <flux:icon.map-pin class="size-8 text-zinc-400" />
+            </div>
+            <flux:heading size="lg" class="mb-1">{{ __('No locations yet') }}</flux:heading>
+            <flux:text class="mb-4 text-zinc-500">{{ __('Add storage locations to this warehouse.') }}</flux:text>
+            <flux:button wire:click="openCreateLocation" variant="primary" icon="plus" size="sm">{{ __('New Location') }}</flux:button>
+        </div>
+    @else
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            @foreach ($this->locations as $location)
+                <div class="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+
+                    {{-- Code + actions --}}
+                    <div class="flex items-start justify-between">
+                        <div>
+                            <span class="inline-flex items-center rounded-lg bg-zinc-100 px-2.5 py-1 text-sm font-mono font-semibold text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">
+                                {{ $location->code }}
+                            </span>
+                            @if ($location->name)
+                                <p class="mt-1 text-xs text-zinc-500">{{ $location->name }}</p>
+                            @endif
+                        </div>
+                        <flux:dropdown>
+                            <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
+                            <flux:menu>
+                                <flux:menu.item icon="pencil" wire:click="openEditLocation({{ $location->id }})">
+                                    {{ __('Edit') }}
+                                </flux:menu.item>
+                                <flux:menu.separator />
+                                <flux:menu.item
+                                    icon="trash"
+                                    variant="danger"
+                                    wire:click="deleteLocation({{ $location->id }})"
+                                    wire:confirm="{{ __('Delete this location?') }}"
+                                >
+                                    {{ __('Delete') }}
+                                </flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    </div>
+
+                    {{-- Stock stats --}}
+                    <div class="flex items-center gap-4 border-t border-zinc-100 pt-3 dark:border-zinc-800">
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.cube class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $location->total_stock }}</span>
+                            <span class="text-zinc-400">{{ __('items') }}</span>
+                        </div>
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.tag class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $location->product_count }}</span>
+                            <span class="text-zinc-400">{{ __('SKUs') }}</span>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+
+    {{-- Add / Edit Location Modal --}}
+    <flux:modal wire:model="showModal" class="max-w-sm">
+        <div class="flex flex-col gap-6 p-6">
+            <div>
+                <flux:heading size="lg">{{ $editingLocationId ? __('Edit Location') : __('New Location') }}</flux:heading>
+                <flux:subheading>{{ $warehouse->name }}</flux:subheading>
+            </div>
+
+            <flux:field>
+                <flux:label>{{ __('Code') }}</flux:label>
+                <flux:input wire:model="code" placeholder="{{ __('e.g. A1') }}" class="uppercase" />
+                <flux:error name="code" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>{{ __('Name') }} <span class="text-xs font-normal text-zinc-400">({{ __('optional') }})</span></flux:label>
+                <flux:input wire:model="locationName" placeholder="{{ __('e.g. Ground shelf') }}" />
+                <flux:error name="locationName" />
+            </flux:field>
+
+            <div class="flex justify-end gap-3">
+                <flux:button wire:click="$set('showModal', false)" variant="ghost">{{ __('Cancel') }}</flux:button>
+                <flux:button wire:click="saveLocation" variant="primary">{{ $editingLocationId ? __('Update') : __('Create') }}</flux:button>
+            </div>
+        </div>
+    </flux:modal>
+
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/categories', App\Livewire\Categories\Index::class)->name('categories.index');
         Route::get('/products', App\Livewire\Products\Index::class)->name('products.index');
         Route::get('/warehouses', App\Livewire\Warehouses\Index::class)->name('warehouses.index');
+        Route::get('/warehouses/{warehouse}', App\Livewire\Warehouses\Show::class)->name('warehouses.show');
         Route::get('/locations', App\Livewire\Locations\Index::class)->name('locations.index');
 
         Route::get('/users', App\Livewire\Users\Index::class)->name('users.index');


### PR DESCRIPTION
## Summary

- **Warehouses index**: replaces flat table with responsive card grid (sm:2, lg:3), card shows name, location, description, locations count + total stock, clickable overlay to detail page
- **Warehouse detail page** (`/warehouses/{warehouse}`): new `Show` Livewire component with location cards showing items/SKUs, stats bar (locations/stock/products), inline add/edit/delete location modal
- **Dashboard**: gradient hero header with date/greeting, three KPI tiles (total stock, movements today, low-stock count), clickable mini-stat cards (admin), improved low-stock list and activity feed
- **Stock overview**: product thumbnails, grouped location rows per product, red row highlight for below-minimum, improved empty state
- **Stock movements**: type icons per movement type, avatar per user, colour-coded +/- quantity
- **Deliveries show**: progress % header, unit counter, notes info banner, warehouse icons in location cells
- **Reports**: icon tabs with blue active state, card-style low-stock list, improved empty states
- **All list pages**: subheadings, icon empty states, monospace location codes, supplier avatar initials

## Test plan
- [x] `./vendor/bin/pint --test` passes
- [x] `php artisan test` passes (180/180)
- [ ] Manual: navigate all pages and verify visual improvements
- [ ] Manual: warehouse show page — add/edit/delete location
- [ ] Manual: dashboard KPI tiles match seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)