### PR TITLE
feat(ui): custom dark sidebar + polished login page

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -5,7 +5,9 @@ namespace App\Livewire;
 use App\Models\Category;
 use App\Models\Location;
 use App\Models\Product;
+use App\Models\StockMovement;
 use App\Models\Warehouse;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -17,11 +19,16 @@ class Dashboard extends Component
     #[Computed]
     public function stats(): array
     {
+        $totalStock = (int) DB::table('stock')->sum('quantity');
+        $movementsToday = StockMovement::whereDate('created_at', today())->count();
+
         return [
             'products' => Product::count(),
             'categories' => Category::count(),
             'warehouses' => Warehouse::count(),
             'locations' => Location::count(),
+            'total_stock' => $totalStock,
+            'movements_today' => $movementsToday,
         ];
     }
 

--- a/app/Livewire/Warehouses/Index.php
+++ b/app/Livewire/Warehouses/Index.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Warehouses;
 
 use App\Models\Warehouse;
 use Flux\Flux;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Rule;
@@ -38,7 +39,10 @@ class Index extends Component
     #[Computed]
     public function warehouses()
     {
+        $totalStockSub = DB::raw('(SELECT COALESCE(SUM(s.quantity), 0) FROM stock s INNER JOIN locations l ON s.location_id = l.id WHERE l.warehouse_id = warehouses.id AND l.deleted_at IS NULL) as total_stock');
+
         return Warehouse::query()
+            ->addSelect(['warehouses.*', $totalStockSub])
             ->when($this->search, fn ($q) => $q->where('name', 'like', "%{$this->search}%")
                 ->orWhere('location', 'like', "%{$this->search}%"))
             ->withCount('locations')

--- a/app/Livewire/Warehouses/Show.php
+++ b/app/Livewire/Warehouses/Show.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Livewire\Warehouses;
+
+use App\Models\Location;
+use App\Models\Warehouse;
+use Flux\Flux;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class Show extends Component
+{
+    public Warehouse $warehouse;
+
+    // Add location modal
+    public bool $showModal = false;
+
+    public ?int $editingLocationId = null;
+
+    public string $code = '';
+
+    public string $locationName = '';
+
+    public function mount(Warehouse $warehouse): void
+    {
+        $this->warehouse = $warehouse;
+    }
+
+    #[Computed]
+    public function locations()
+    {
+        $totalStockSub = DB::raw('(SELECT COALESCE(SUM(s.quantity), 0) FROM stock s WHERE s.location_id = locations.id) as total_stock');
+        $productCountSub = DB::raw('(SELECT COUNT(DISTINCT s.product_id) FROM stock s WHERE s.location_id = locations.id AND s.quantity > 0) as product_count');
+
+        return $this->warehouse->locations()
+            ->addSelect(['locations.*', $totalStockSub, $productCountSub])
+            ->orderBy('code')
+            ->get();
+    }
+
+    #[Computed]
+    public function stats(): array
+    {
+        $locations = $this->locations;
+
+        return [
+            'location_count' => $locations->count(),
+            'total_stock' => $locations->sum('total_stock'),
+            'product_count' => DB::table('stock')
+                ->join('locations', 'stock.location_id', '=', 'locations.id')
+                ->where('locations.warehouse_id', $this->warehouse->id)
+                ->whereNull('locations.deleted_at')
+                ->distinct('stock.product_id')
+                ->count('stock.product_id'),
+        ];
+    }
+
+    public function openCreateLocation(): void
+    {
+        $this->reset(['code', 'locationName', 'editingLocationId']);
+        $this->resetValidation();
+        $this->showModal = true;
+    }
+
+    public function openEditLocation(Location $location): void
+    {
+        $this->editingLocationId = $location->id;
+        $this->code = $location->code;
+        $this->locationName = $location->name ?? '';
+        $this->resetValidation();
+        $this->showModal = true;
+    }
+
+    public function saveLocation(): void
+    {
+        $this->validate([
+            'code' => 'required|string|max:20',
+            'locationName' => 'nullable|string|max:100',
+        ]);
+
+        if ($this->editingLocationId) {
+            $loc = Location::findOrFail($this->editingLocationId);
+            $loc->update([
+                'code' => strtoupper($this->code),
+                'name' => $this->locationName ?: null,
+            ]);
+            activity()->causedBy(auth()->user())->performedOn($loc)->log('updated');
+            Flux::toast(__('Location updated.'), variant: 'success');
+        } else {
+            $loc = $this->warehouse->locations()->create([
+                'code' => strtoupper($this->code),
+                'name' => $this->locationName ?: null,
+            ]);
+            activity()->causedBy(auth()->user())->performedOn($loc)->log('created');
+            Flux::toast(__('Location created.'), variant: 'success');
+        }
+
+        $this->showModal = false;
+        $this->reset(['code', 'locationName', 'editingLocationId']);
+        unset($this->locations, $this->stats);
+    }
+
+    public function deleteLocation(Location $location): void
+    {
+        $location->delete();
+        activity()->causedBy(auth()->user())->performedOn($location)->log('deleted');
+        Flux::toast(__('Location deleted.'), variant: 'success');
+        unset($this->locations, $this->stats);
+    }
+
+    public function render()
+    {
+        return view('livewire.warehouses.show');
+    }
+}

--- a/resources/views/components/app-logo-icon.blade.php
+++ b/resources/views/components/app-logo-icon.blade.php
@@ -1,8 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 42" {{ $attributes }}>
-    <path 
-        fill="currentColor" 
-        fill-rule="evenodd" 
-        clip-rule="evenodd"
-        d="M17.2 5.633 8.6.855 0 5.633v26.51l16.2 9 16.2-9v-8.442l7.6-4.223V9.856l-8.6-4.777-8.6 4.777V18.3l-5.6 3.111V5.633ZM38 18.301l-5.6 3.11v-6.157l5.6-3.11V18.3Zm-1.06-7.856-5.54 3.078-5.54-3.079 5.54-3.078 5.54 3.079ZM24.8 18.3v-6.157l5.6 3.111v6.158L24.8 18.3Zm-1 1.732 5.54 3.078-13.14 7.302-5.54-3.078 13.14-7.3v-.002Zm-16.2 7.89 7.6 4.222V38.3L2 30.966V7.92l5.6 3.111v16.892ZM8.6 9.3 3.06 6.222 8.6 3.143l5.54 3.08L8.6 9.3Zm21.8 15.51-13.2 7.334V38.3l13.2-7.334v-6.156ZM9.6 11.034l5.6-3.11v14.6l-5.6 3.11v-14.6Z"
-    />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 42" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" {{ $attributes }}>
+    {{-- Warehouse building: roof + body + door cutout + window cutouts --}}
+    <path d="M20 1L0 13v28a1 1 0 001 1h38a1 1 0 001-1V13L20 1z
+             M14 42V28h12v14H14z
+             M5 17h8v6H5V17z
+             M27 17h8v6H27V17z" />
 </svg>

--- a/resources/views/components/auth-header.blade.php
+++ b/resources/views/components/auth-header.blade.php
@@ -3,7 +3,7 @@
     'description',
 ])
 
-<div class="flex w-full flex-col text-center">
-    <flux:heading size="xl">{{ $title }}</flux:heading>
-    <flux:subheading>{{ $description }}</flux:subheading>
+<div class="flex w-full flex-col gap-1">
+    <h1 class="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">{{ $title }}</h1>
+    <p class="text-sm text-zinc-500">{{ $description }}</p>
 </div>

--- a/resources/views/components/nav-item.blade.php
+++ b/resources/views/components/nav-item.blade.php
@@ -1,0 +1,23 @@
+@props([
+    'href'   => '#',
+    'active' => false,
+    'icon'   => null,
+])
+
+<a
+    href="{{ $href }}"
+    wire:navigate
+    @class([
+        'group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-100',
+        'bg-blue-600 text-white shadow-sm shadow-blue-900/40' => $active,
+        'text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100' => ! $active,
+    ])
+>
+    @if($icon)
+        <flux:icon
+            :icon="$icon"
+            class="size-4 shrink-0 {{ $active ? 'text-white' : 'text-zinc-500 group-hover:text-zinc-300' }}"
+        />
+    @endif
+    {{ $slot }}
+</a>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -3,120 +3,165 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white dark:bg-zinc-800">
-        <flux:sidebar sticky collapsible="mobile" class="border-e border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
-            <flux:sidebar.header>
-                <x-app-logo :sidebar="true" href="{{ route('dashboard') }}" wire:navigate />
-                <flux:sidebar.collapse class="lg:hidden" />
+    <body class="min-h-screen bg-zinc-100 dark:bg-zinc-900">
+
+        {{-- ===== SIDEBAR ===== --}}
+        <flux:sidebar sticky collapsible="mobile" class="w-60 border-e border-zinc-800/60 bg-zinc-950 dark:border-zinc-800/60 dark:bg-zinc-950">
+
+            {{-- Brand --}}
+            <flux:sidebar.header class="border-b border-zinc-800/60 px-4 py-4">
+                <a href="{{ route('dashboard') }}" wire:navigate class="flex items-center gap-3">
+                    <div class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-blue-700 shadow-md shadow-blue-900/40">
+                        <x-app-logo-icon class="size-4 fill-current text-white" />
+                    </div>
+                    <span class="text-sm font-semibold tracking-wide text-white">WareTrack</span>
+                </a>
+                <flux:sidebar.collapse class="ml-auto text-zinc-500 hover:text-zinc-300 lg:hidden" />
             </flux:sidebar.header>
 
-            <flux:sidebar.nav>
-                <flux:sidebar.group :heading="__('General')" class="grid">
-                    <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
-                        {{ __('Dashboard') }}
-                    </flux:sidebar.item>
+            {{-- Navigation --}}
+            <flux:sidebar.nav class="flex flex-col gap-5 px-3 py-4">
 
-                    <flux:sidebar.item icon="cube" :href="route('stock.index')" :current="request()->routeIs('stock.*')" wire:navigate>
-                        {{ __('Stock') }}
-                    </flux:sidebar.item>
+                {{-- General --}}
+                <div>
+                    <p class="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-widest text-zinc-600">{{ __('General') }}</p>
+                    <div class="flex flex-col gap-0.5">
+                        <x-nav-item href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')" icon="home">
+                            {{ __('Dashboard') }}
+                        </x-nav-item>
+                        <x-nav-item href="{{ route('stock.index') }}" :active="request()->routeIs('stock.*')" icon="cube">
+                            {{ __('Stock') }}
+                        </x-nav-item>
+                        <x-nav-item href="{{ route('reports.index') }}" :active="request()->routeIs('reports.*')" icon="chart-bar">
+                            {{ __('Reports') }}
+                        </x-nav-item>
+                        <x-nav-item href="{{ route('deliveries.index') }}" :active="request()->routeIs('deliveries.*')" icon="truck">
+                            {{ __('Deliveries') }}
+                        </x-nav-item>
+                        <x-nav-item href="{{ route('suppliers.index') }}" :active="request()->routeIs('suppliers.*')" icon="building-storefront">
+                            {{ __('Suppliers') }}
+                        </x-nav-item>
+                    </div>
+                </div>
 
-                    <flux:sidebar.item icon="chart-bar" :href="route('reports.index')" :current="request()->routeIs('reports.*')" wire:navigate>
-                        {{ __('Reports') }}
-                    </flux:sidebar.item>
-
-                    <flux:sidebar.item icon="truck" :href="route('deliveries.index')" :current="request()->routeIs('deliveries.*')" wire:navigate>
-                        {{ __('Deliveries') }}
-                    </flux:sidebar.item>
-
-                    <flux:sidebar.item icon="building-storefront" :href="route('suppliers.index')" :current="request()->routeIs('suppliers.*')" wire:navigate>
-                        {{ __('Suppliers') }}
-                    </flux:sidebar.item>
-                </flux:sidebar.group>
-
+                {{-- Admin --}}
                 @if(auth()->user()?->isAdmin())
-                    <flux:sidebar.group :heading="__('Admin')" class="grid">
-                        <flux:sidebar.item icon="tag" :href="route('categories.index')" :current="request()->routeIs('categories.*')" wire:navigate>
-                            {{ __('Categories') }}
-                        </flux:sidebar.item>
-
-                        <flux:sidebar.item icon="archive-box" :href="route('products.index')" :current="request()->routeIs('products.*')" wire:navigate>
-                            {{ __('Products') }}
-                        </flux:sidebar.item>
-
-                        <flux:sidebar.item icon="building-office" :href="route('warehouses.index')" :current="request()->routeIs('warehouses.*')" wire:navigate>
-                            {{ __('Warehouses') }}
-                        </flux:sidebar.item>
-
-                        <flux:sidebar.item icon="map-pin" :href="route('locations.index')" :current="request()->routeIs('locations.*')" wire:navigate>
-                            {{ __('Locations') }}
-                        </flux:sidebar.item>
-
-                        <flux:sidebar.item icon="users" :href="route('users.index')" :current="request()->routeIs('users.*')" wire:navigate>
-                            {{ __('Users') }}
-                        </flux:sidebar.item>
-                    </flux:sidebar.group>
+                    <div>
+                        <p class="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-widest text-zinc-600">{{ __('Admin') }}</p>
+                        <div class="flex flex-col gap-0.5">
+                            <x-nav-item href="{{ route('categories.index') }}" :active="request()->routeIs('categories.*')" icon="tag">
+                                {{ __('Categories') }}
+                            </x-nav-item>
+                            <x-nav-item href="{{ route('products.index') }}" :active="request()->routeIs('products.*')" icon="archive-box">
+                                {{ __('Products') }}
+                            </x-nav-item>
+                            <x-nav-item href="{{ route('warehouses.index') }}" :active="request()->routeIs('warehouses.*')" icon="building-office">
+                                {{ __('Warehouses') }}
+                            </x-nav-item>
+                            <x-nav-item href="{{ route('locations.index') }}" :active="request()->routeIs('locations.*')" icon="map-pin">
+                                {{ __('Locations') }}
+                            </x-nav-item>
+                            <x-nav-item href="{{ route('users.index') }}" :active="request()->routeIs('users.*')" icon="users">
+                                {{ __('Users') }}
+                            </x-nav-item>
+                        </div>
+                    </div>
                 @endif
+
             </flux:sidebar.nav>
 
             <flux:spacer />
 
-            <flux:sidebar.nav>
-                <flux:sidebar.item icon="folder-git-2" href="https://github.com/Yaman69420/WareTrack" target="_blank">
+            {{-- Bottom links --}}
+            <div class="border-t border-zinc-800/60 px-3 py-3">
+                <a
+                    href="https://github.com/Yaman69420/WareTrack"
+                    target="_blank"
+                    class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm text-zinc-500 transition hover:bg-zinc-800/60 hover:text-zinc-300"
+                >
+                    <flux:icon.code-bracket class="size-4 shrink-0" />
                     {{ __('Repository') }}
-                </flux:sidebar.item>
-            </flux:sidebar.nav>
+                </a>
+            </div>
 
-            <x-desktop-user-menu class="hidden lg:block" :name="auth()->user()->name" />
-        </flux:sidebar>
+            {{-- User footer --}}
+            <div class="border-t border-zinc-800/60 p-3">
+                <flux:dropdown position="top" align="start" class="w-full">
+                    <button class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition hover:bg-zinc-800/60">
+                        <flux:avatar
+                            size="sm"
+                            :name="auth()->user()->name"
+                            :initials="auth()->user()->initials()"
+                            class="shrink-0"
+                        />
+                        <div class="flex min-w-0 flex-1 flex-col text-left">
+                            <span class="truncate text-sm font-medium text-zinc-100">{{ auth()->user()->name }}</span>
+                            <span class="truncate text-xs text-zinc-500">
+                                {{ auth()->user()->isAdmin() ? __('Administrator') : __('Warehouse Worker') }}
+                            </span>
+                        </div>
+                        <flux:icon.chevrons-up-down class="size-4 shrink-0 text-zinc-500" />
+                    </button>
 
-        <!-- Mobile User Menu -->
-        <flux:header class="lg:hidden">
-            <flux:sidebar.toggle class="lg:hidden" icon="bars-2" inset="left" />
-
-            <flux:spacer />
-
-            <flux:dropdown position="top" align="end">
-                <flux:profile
-                    :initials="auth()->user()->initials()"
-                    icon-trailing="chevron-down"
-                />
-
-                <flux:menu>
-                    <flux:menu.radio.group>
-                        <div class="p-0 text-sm font-normal">
-                            <div class="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
-                                <flux:avatar
-                                    :name="auth()->user()->name"
-                                    :initials="auth()->user()->initials()"
-                                />
-
-                                <div class="grid flex-1 text-start text-sm leading-tight">
-                                    <flux:heading class="truncate">{{ auth()->user()->name }}</flux:heading>
-                                    <flux:text class="truncate">{{ auth()->user()->email }}</flux:text>
-                                </div>
+                    <flux:menu class="w-56">
+                        <div class="flex items-center gap-3 px-3 py-2.5">
+                            <flux:avatar
+                                :name="auth()->user()->name"
+                                :initials="auth()->user()->initials()"
+                                size="sm"
+                            />
+                            <div class="min-w-0">
+                                <p class="truncate text-sm font-medium">{{ auth()->user()->name }}</p>
+                                <p class="truncate text-xs text-zinc-500">{{ auth()->user()->email }}</p>
                             </div>
                         </div>
-                    </flux:menu.radio.group>
-
-                    <flux:menu.separator />
-
-                    <flux:menu.radio.group>
+                        <flux:menu.separator />
                         <flux:menu.item :href="route('profile.edit')" icon="cog" wire:navigate>
                             {{ __('Settings') }}
                         </flux:menu.item>
-                    </flux:menu.radio.group>
+                        <flux:menu.separator />
+                        <form method="POST" action="{{ route('logout') }}" class="w-full">
+                            @csrf
+                            <flux:menu.item as="button" type="submit" icon="arrow-right-start-on-rectangle" class="w-full cursor-pointer" data-test="logout-button">
+                                {{ __('Log out') }}
+                            </flux:menu.item>
+                        </form>
+                    </flux:menu>
+                </flux:dropdown>
+            </div>
+        </flux:sidebar>
 
+        {{-- ===== MOBILE HEADER ===== --}}
+        <flux:header class="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950 lg:hidden">
+            <flux:sidebar.toggle class="text-zinc-500 lg:hidden" icon="bars-2" inset="left" />
+            <div class="flex items-center gap-2">
+                <div class="flex size-6 items-center justify-center rounded bg-gradient-to-br from-blue-500 to-blue-700">
+                    <x-app-logo-icon class="size-3.5 fill-current text-white" />
+                </div>
+                <span class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">WareTrack</span>
+            </div>
+            <flux:spacer />
+            <flux:dropdown position="bottom" align="end">
+                <flux:avatar
+                    size="sm"
+                    :name="auth()->user()->name"
+                    :initials="auth()->user()->initials()"
+                    class="cursor-pointer"
+                />
+                <flux:menu>
+                    <div class="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
+                        <flux:avatar :name="auth()->user()->name" :initials="auth()->user()->initials()" />
+                        <div class="grid flex-1 text-start text-sm leading-tight">
+                            <span class="truncate font-medium">{{ auth()->user()->name }}</span>
+                            <span class="truncate text-xs text-zinc-500">{{ auth()->user()->email }}</span>
+                        </div>
+                    </div>
                     <flux:menu.separator />
-
+                    <flux:menu.item :href="route('profile.edit')" icon="cog" wire:navigate>{{ __('Settings') }}</flux:menu.item>
+                    <flux:menu.separator />
                     <form method="POST" action="{{ route('logout') }}" class="w-full">
                         @csrf
-                        <flux:menu.item
-                            as="button"
-                            type="submit"
-                            icon="arrow-right-start-on-rectangle"
-                            class="w-full cursor-pointer"
-                            data-test="logout-button"
-                        >
+                        <flux:menu.item as="button" type="submit" icon="arrow-right-start-on-rectangle" class="w-full cursor-pointer" data-test="logout-button">
                             {{ __('Log out') }}
                         </flux:menu.item>
                     </form>

--- a/resources/views/layouts/auth/split.blade.php
+++ b/resources/views/layouts/auth/split.blade.php
@@ -95,39 +95,47 @@
                     </li>
                 </ul>
 
-                {{-- Bottom badge --}}
+                {{-- Bottom status dot --}}
                 <div class="wt-badge relative z-10 mt-auto">
-                    <span class="inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-900/80 px-3 py-1 text-xs text-zinc-500 backdrop-blur-sm">
+                    <span class="inline-flex items-center gap-1.5 text-xs text-zinc-600">
                         <span class="size-1.5 rounded-full bg-green-400"></span>
-                        Laravel 13 · Livewire 4 · Flux UI
+                        All systems operational
                     </span>
                 </div>
             </div>
 
             {{-- RIGHT PANEL: form --}}
-            <div class="wt-form-panel relative flex w-full items-center justify-center bg-white px-8 py-12 dark:bg-zinc-950 lg:p-12">
+            <div class="wt-form-panel relative flex w-full items-center justify-center overflow-hidden bg-[#080c14] px-8 py-12 lg:p-12">
 
-                {{-- Subtle background grid pattern --}}
-                <div class="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:32px_32px]"></div>
+                {{-- Matching glow orbs --}}
+                <div class="pointer-events-none absolute right-0 top-1/3 size-80 rounded-full bg-blue-600/10 blur-3xl"></div>
+                <div class="pointer-events-none absolute bottom-0 left-1/4 size-56 rounded-full bg-indigo-600/10 blur-3xl"></div>
 
-                <div class="relative mx-auto flex w-full max-w-sm flex-col gap-8">
+                <div class="relative mx-auto flex w-full max-w-sm flex-col gap-6">
 
                     {{-- Mobile logo --}}
-                    <a href="{{ route('home') }}" wire:navigate
-                       class="flex items-center gap-3 font-medium lg:hidden">
+                    <a href="{{ route('home') }}" wire:navigate class="flex items-center gap-3 font-medium lg:hidden">
                         <span class="flex size-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-blue-700 shadow-md">
                             <x-app-logo-icon class="size-5 fill-current text-white" />
                         </span>
-                        <span class="text-base font-semibold text-zinc-900 dark:text-zinc-100">WareTrack</span>
+                        <span class="text-base font-semibold text-white">WareTrack</span>
                     </a>
 
-                    <div class="rounded-2xl border border-zinc-200/80 bg-white/80 p-8 shadow-xl shadow-zinc-200/50 backdrop-blur-sm dark:border-zinc-800/80 dark:bg-zinc-900/80 dark:shadow-none">
-                        {{ $slot }}
+                    {{-- Card --}}
+                    <div class="rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl shadow-black/60">
+                        {{-- Card brand header --}}
+                        <div class="flex flex-col items-center gap-3 border-b border-zinc-800 px-8 py-6">
+                            <div class="flex size-11 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-700 shadow-lg shadow-blue-900/50">
+                                <x-app-logo-icon class="size-5 fill-current text-white" />
+                            </div>
+                            <p class="text-sm font-semibold text-white">WareTrack</p>
+                        </div>
+                        {{-- Form area --}}
+                        <div class="px-8 py-6">
+                            {{ $slot }}
+                        </div>
                     </div>
 
-                    <p class="text-center text-xs text-zinc-400">
-                        &copy; {{ date('Y') }} WareTrack &mdash; {{ __('Built with') }} Laravel 13 + Livewire 4
-                    </p>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/auth/split.blade.php
+++ b/resources/views/layouts/auth/split.blade.php
@@ -9,92 +9,125 @@
         <div class="relative grid h-dvh flex-col items-center justify-center lg:max-w-none lg:grid-cols-2 lg:px-0">
 
             {{-- LEFT PANEL --}}
-            <div class="wt-panel relative hidden h-full flex-col overflow-hidden bg-zinc-900 p-10 text-white lg:flex">
+            <div class="wt-panel relative hidden h-full flex-col overflow-hidden bg-[#080c14] p-10 text-white lg:flex">
 
-                {{-- Animated grid background --}}
-                <canvas id="wt-grid" class="absolute inset-0 opacity-20"></canvas>
+                {{-- Blue glow orb --}}
+                <div class="absolute -left-20 top-0 size-72 rounded-full bg-blue-600/20 blur-3xl"></div>
+                <div class="absolute bottom-20 right-0 size-64 rounded-full bg-indigo-600/15 blur-3xl"></div>
+
+                {{-- Animated dot grid background --}}
+                <canvas id="wt-grid" class="absolute inset-0 opacity-30"></canvas>
 
                 {{-- Logo --}}
-                <a href="{{ route('home') }}" wire:navigate
-                   class="wt-logo relative z-10 flex items-center gap-3">
-                    <span class="flex h-10 w-10 items-center justify-center rounded-lg bg-zinc-700">
-                        <x-app-logo-icon class="h-6 w-6 fill-current text-white" />
+                <a href="{{ route('home') }}" wire:navigate class="wt-logo relative z-10 flex items-center gap-3">
+                    <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-700 shadow-lg shadow-blue-900/50">
+                        <x-app-logo-icon class="h-5 w-5 fill-current text-white" />
                     </span>
                     <span class="text-xl font-bold tracking-tight">WareTrack</span>
                 </a>
 
                 {{-- Hero text --}}
-                <div class="relative z-10 mt-16">
+                <div class="relative z-10 mt-14">
+                    <div class="mb-3 inline-flex items-center gap-1.5 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-400">
+                        <span class="size-1.5 rounded-full bg-blue-400"></span>
+                        Warehouse Management System
+                    </div>
                     <p class="wt-tagline text-4xl font-bold leading-tight tracking-tight text-white">
-                        Warehouse management,<br>
-                        <span class="text-zinc-400">simplified.</span>
+                        Manage stock<br>
+                        <span class="bg-gradient-to-r from-blue-400 to-indigo-400 bg-clip-text text-transparent">across any scale.</span>
                     </p>
-                    <p class="wt-sub mt-4 text-base text-zinc-400">
-                        Real-time stock tracking across multiple warehouses and locations — with full audit logging.
+                    <p class="wt-sub mt-4 text-sm leading-relaxed text-zinc-400">
+                        Real-time inventory tracking across multiple warehouses, locations and teams — with full audit trail.
                     </p>
                 </div>
 
+                {{-- Mini stats preview --}}
+                <div class="wt-stats relative z-10 mt-10 grid grid-cols-3 gap-3">
+                    <div class="rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur-sm">
+                        <p class="text-xl font-bold text-white">3</p>
+                        <p class="mt-0.5 text-xs text-zinc-500">Warehouses</p>
+                    </div>
+                    <div class="rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur-sm">
+                        <p class="text-xl font-bold text-white">20</p>
+                        <p class="mt-0.5 text-xs text-zinc-500">Products</p>
+                    </div>
+                    <div class="rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur-sm">
+                        <p class="text-xl font-bold text-white">100%</p>
+                        <p class="mt-0.5 text-xs text-zinc-500">Traceable</p>
+                    </div>
+                </div>
+
                 {{-- Feature highlights --}}
-                <ul class="relative z-10 mt-12 space-y-5">
+                <ul class="relative z-10 mt-8 space-y-4">
                     <li class="wt-feature flex items-start gap-3">
-                        <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-zinc-700">
-                            <svg class="h-3.5 w-3.5 text-zinc-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                        <span class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-blue-500/20 ring-1 ring-blue-500/30">
+                            <svg class="h-3 w-3 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7c0-2-1-3-3-3H7C5 4 4 5 4 7z" />
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 11h6M9 15h4" />
                             </svg>
                         </span>
                         <div>
                             <p class="text-sm font-medium text-white">Multi-location stock management</p>
-                            <p class="text-xs text-zinc-400">Track inventory across warehouses and locations in real-time.</p>
+                            <p class="text-xs text-zinc-500">Track inventory across warehouses and locations in real-time.</p>
                         </div>
                     </li>
                     <li class="wt-feature flex items-start gap-3">
-                        <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-zinc-700">
-                            <svg class="h-3.5 w-3.5 text-zinc-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                        <span class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-indigo-500/20 ring-1 ring-indigo-500/30">
+                            <svg class="h-3 w-3 text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                             </svg>
                         </span>
                         <div>
-                            <p class="text-sm font-medium text-white">Full delivery & supplier tracking</p>
-                            <p class="text-xs text-zinc-400">From supplier order to stock — every step logged.</p>
+                            <p class="text-sm font-medium text-white">Delivery & supplier tracking</p>
+                            <p class="text-xs text-zinc-500">From supplier order to stock — every step logged.</p>
                         </div>
                     </li>
                     <li class="wt-feature flex items-start gap-3">
-                        <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-zinc-700">
-                            <svg class="h-3.5 w-3.5 text-zinc-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                        <span class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-emerald-500/20 ring-1 ring-emerald-500/30">
+                            <svg class="h-3 w-3 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                             </svg>
                         </span>
                         <div>
                             <p class="text-sm font-medium text-white">Low-stock alerts & reports</p>
-                            <p class="text-xs text-zinc-400">Instant overview of products below minimum stock level.</p>
+                            <p class="text-xs text-zinc-500">Instant overview of products below minimum stock level.</p>
                         </div>
                     </li>
                 </ul>
 
                 {{-- Bottom badge --}}
                 <div class="wt-badge relative z-10 mt-auto">
-                    <span class="inline-flex items-center gap-1.5 rounded-full bg-zinc-800 px-3 py-1 text-xs text-zinc-400">
-                        <span class="h-1.5 w-1.5 rounded-full bg-green-400"></span>
-                        Built with Laravel 13 + Livewire 4
+                    <span class="inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-900/80 px-3 py-1 text-xs text-zinc-500 backdrop-blur-sm">
+                        <span class="size-1.5 rounded-full bg-green-400"></span>
+                        Laravel 13 · Livewire 4 · Flux UI
                     </span>
                 </div>
             </div>
 
             {{-- RIGHT PANEL: form --}}
-            <div class="wt-form-panel flex w-full items-center justify-center px-8 py-12 lg:p-12">
-                <div class="mx-auto flex w-full max-w-sm flex-col gap-6">
+            <div class="wt-form-panel relative flex w-full items-center justify-center bg-white px-8 py-12 dark:bg-zinc-950 lg:p-12">
+
+                {{-- Subtle background grid pattern --}}
+                <div class="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:32px_32px]"></div>
+
+                <div class="relative mx-auto flex w-full max-w-sm flex-col gap-8">
 
                     {{-- Mobile logo --}}
                     <a href="{{ route('home') }}" wire:navigate
-                       class="flex flex-col items-center gap-2 font-medium lg:hidden">
-                        <span class="flex h-9 w-9 items-center justify-center rounded-md bg-zinc-800">
+                       class="flex items-center gap-3 font-medium lg:hidden">
+                        <span class="flex size-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-blue-700 shadow-md">
                             <x-app-logo-icon class="size-5 fill-current text-white" />
                         </span>
-                        <span class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">WareTrack</span>
+                        <span class="text-base font-semibold text-zinc-900 dark:text-zinc-100">WareTrack</span>
                     </a>
 
-                    {{ $slot }}
+                    <div class="rounded-2xl border border-zinc-200/80 bg-white/80 p-8 shadow-xl shadow-zinc-200/50 backdrop-blur-sm dark:border-zinc-800/80 dark:bg-zinc-900/80 dark:shadow-none">
+                        {{ $slot }}
+                    </div>
+
+                    <p class="text-center text-xs text-zinc-400">
+                        &copy; {{ date('Y') }} WareTrack &mdash; {{ __('Built with') }} Laravel 13 + Livewire 4
+                    </p>
                 </div>
             </div>
         </div>
@@ -189,11 +222,12 @@
                 if (typeof gsap !== 'undefined') {
                     const tl = gsap.timeline({ defaults: { ease: 'power3.out' } });
 
-                    tl.from('.wt-logo',    { y: -24, opacity: 0, duration: 0.6 })
-                      .from('.wt-tagline', { y: 20,  opacity: 0, duration: 0.6 }, '-=0.3')
-                      .from('.wt-sub',     { y: 16,  opacity: 0, duration: 0.5 }, '-=0.3')
-                      .from('.wt-feature', { x: -20, opacity: 0, duration: 0.45, stagger: 0.12 }, '-=0.2')
-                      .from('.wt-badge',   { opacity: 0, duration: 0.4 }, '-=0.1')
+                    tl.from('.wt-logo',       { y: -24, opacity: 0, duration: 0.6 })
+                      .from('.wt-tagline',    { y: 20,  opacity: 0, duration: 0.6 }, '-=0.3')
+                      .from('.wt-sub',        { y: 16,  opacity: 0, duration: 0.5 }, '-=0.3')
+                      .from('.wt-stats > *',  { y: 12,  opacity: 0, duration: 0.4, stagger: 0.08 }, '-=0.3')
+                      .from('.wt-feature',    { x: -20, opacity: 0, duration: 0.45, stagger: 0.12 }, '-=0.2')
+                      .from('.wt-badge',      { opacity: 0, duration: 0.4 }, '-=0.1')
                       .from('.wt-form-panel', { x: 30, opacity: 0, duration: 0.6 }, '-=0.8');
                 }
             });

--- a/resources/views/livewire/categories/index.blade.php
+++ b/resources/views/livewire/categories/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Categories') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Categories') }}</flux:heading>
+            <flux:subheading>{{ __('Organise your products into logical groups') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Category') }}
         </flux:button>
@@ -31,15 +34,22 @@
             @forelse ($this->categories as $category)
                 <flux:table.row :key="$category->id">
                     <flux:table.cell variant="strong">
-                        {{ $category->name }}
+                        <div class="flex items-center gap-2.5">
+                            <div class="rounded-md bg-violet-50 p-1.5 dark:bg-violet-900/30">
+                                <flux:icon.tag class="size-4 text-violet-600 dark:text-violet-400" />
+                            </div>
+                            {{ $category->name }}
+                        </div>
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        {{ $category->description ?? '—' }}
+                        <span class="text-zinc-500">{{ $category->description ?? '—' }}</span>
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        <flux:badge variant="outline">{{ $category->products_count }}</flux:badge>
+                        <flux:badge variant="{{ $category->products_count > 0 ? 'outline' : 'ghost' }}">
+                            {{ $category->products_count }} {{ __('products') }}
+                        </flux:badge>
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -71,8 +81,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="5" class="py-12 text-center">
-                        {{ $search ? __('No categories match your search.') : __('No categories yet.') }}
+                    <flux:table.cell colspan="5" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.tag class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $search ? __('No categories match your search.') : __('No categories yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,130 +1,216 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
-    {{-- Header --}}
-    <div>
-        <flux:heading size="xl">{{ __('Dashboard') }}</flux:heading>
-        <flux:subheading>{{ __('Welcome back,') }} {{ auth()->user()->name }}</flux:subheading>
+    {{-- Hero header --}}
+    <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-blue-600 to-blue-800 px-6 py-8 text-white shadow-lg dark:from-blue-700 dark:to-blue-900">
+        <div class="relative z-10">
+            <p class="text-sm font-medium text-blue-200">{{ now()->format('l, j F Y') }}</p>
+            <h1 class="mt-1 text-3xl font-bold">{{ __('Welcome back,') }} {{ auth()->user()->name }} 👋</h1>
+            <p class="mt-1 text-blue-200">{{ __('Here\'s what\'s happening in your warehouses today.') }}</p>
+        </div>
+        {{-- Decorative circles --}}
+        <div class="absolute -right-8 -top-8 size-40 rounded-full bg-white/5"></div>
+        <div class="absolute -bottom-10 right-20 size-28 rounded-full bg-white/5"></div>
     </div>
 
-    {{-- Stats Cards --}}
+    {{-- Stats grid --}}
     @php $isAdmin = auth()->user()->isAdmin(); @endphp
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <a href="{{ $isAdmin ? route('products.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-blue-100 p-3 dark:bg-blue-900/30">
-                    <flux:icon.archive-box class="size-6 text-blue-600 dark:text-blue-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Products') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['products'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
 
-        <a href="{{ $isAdmin ? route('categories.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-purple-100 p-3 dark:bg-purple-900/30">
-                    <flux:icon.tag class="size-6 text-purple-600 dark:text-purple-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Categories') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['categories'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+        {{-- Total stock (wide) --}}
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-xl bg-emerald-50 p-3 dark:bg-emerald-900/30">
+                <flux:icon.cube class="size-7 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <div>
+                <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100">{{ number_format($this->stats['total_stock']) }}</p>
+                <p class="text-sm text-zinc-500">{{ __('Items in stock') }}</p>
+            </div>
+        </div>
 
-        <a href="{{ $isAdmin ? route('warehouses.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-amber-100 p-3 dark:bg-amber-900/30">
-                    <flux:icon.building-office class="size-6 text-amber-600 dark:text-amber-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Warehouses') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['warehouses'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+        {{-- Movements today (wide) --}}
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
+                <flux:icon.arrow-path class="size-7 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+                <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['movements_today'] }}</p>
+                <p class="text-sm text-zinc-500">{{ __('Movements today') }}</p>
+            </div>
+        </div>
 
-        <a href="{{ $isAdmin ? route('locations.index') : '#' }}" @if($isAdmin) wire:navigate @endif>
-            <flux:card class="flex items-center gap-4 transition {{ $isAdmin ? 'hover:shadow-md' : '' }}">
-                <div class="rounded-lg bg-green-100 p-3 dark:bg-green-900/30">
-                    <flux:icon.map-pin class="size-6 text-green-600 dark:text-green-400" />
-                </div>
-                <div>
-                    <flux:text class="text-sm text-zinc-500">{{ __('Locations') }}</flux:text>
-                    <flux:heading size="xl">{{ $this->stats['locations'] }}</flux:heading>
-                </div>
-            </flux:card>
-        </a>
+        {{-- Low stock alert count (wide) --}}
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border {{ $this->lowStockProducts->isNotEmpty() ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900' }} p-5">
+            <div class="rounded-xl {{ $this->lowStockProducts->isNotEmpty() ? 'bg-red-100 dark:bg-red-900/30' : 'bg-zinc-100 dark:bg-zinc-800' }} p-3">
+                <flux:icon.exclamation-triangle class="size-7 {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-600 dark:text-red-400' : 'text-zinc-400' }}" />
+            </div>
+            <div>
+                <p class="text-3xl font-bold {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-700 dark:text-red-400' : 'text-zinc-900 dark:text-zinc-100' }}">{{ $this->lowStockProducts->count() }}</p>
+                <p class="text-sm {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-500' : 'text-zinc-500' }}">{{ __('Low stock alerts') }}</p>
+            </div>
+        </div>
     </div>
 
-    {{-- Bottom Grid --}}
+    {{-- Small counters --}}
+    <div class="grid gap-4 sm:grid-cols-4">
+        @if($isAdmin)
+        <a href="{{ route('products.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-blue-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-700">
+            <div class="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
+                <flux:icon.archive-box class="size-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['products'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Products') }}</p>
+            </div>
+        </a>
+        <a href="{{ route('categories.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-violet-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-violet-700">
+            <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
+                <flux:icon.tag class="size-5 text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['categories'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Categories') }}</p>
+            </div>
+        </a>
+        <a href="{{ route('warehouses.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-amber-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-amber-700">
+            <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <flux:icon.building-office class="size-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['warehouses'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Warehouses') }}</p>
+            </div>
+        </a>
+        <a href="{{ route('locations.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-green-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-green-700">
+            <div class="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
+                <flux:icon.map-pin class="size-5 text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['locations'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Locations') }}</p>
+            </div>
+        </a>
+        @else
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
+                <flux:icon.archive-box class="size-5 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['products'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Products') }}</p>
+            </div>
+        </div>
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
+                <flux:icon.tag class="size-5 text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['categories'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Categories') }}</p>
+            </div>
+        </div>
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <flux:icon.building-office class="size-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['warehouses'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Warehouses') }}</p>
+            </div>
+        </div>
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
+                <flux:icon.map-pin class="size-5 text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+                <p class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['locations'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Locations') }}</p>
+            </div>
+        </div>
+        @endif
+    </div>
+
+    {{-- Bottom grid --}}
     <div class="grid gap-6 lg:grid-cols-2">
 
         {{-- Low Stock Alerts --}}
-        <flux:card class="flex flex-col gap-4">
+        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
             <div class="flex items-center justify-between">
-                <flux:heading>{{ __('Low Stock Alerts') }}</flux:heading>
+                <div class="flex items-center gap-2">
+                    <flux:icon.exclamation-triangle class="size-5 text-red-500" />
+                    <flux:heading>{{ __('Low Stock Alerts') }}</flux:heading>
+                </div>
                 @if($this->lowStockProducts->isNotEmpty())
                     <flux:badge variant="danger">{{ $this->lowStockProducts->count() }}</flux:badge>
                 @endif
             </div>
 
             @if($this->lowStockProducts->isEmpty())
-                <div class="flex flex-1 flex-col items-center justify-center py-8 text-center">
-                    <flux:icon.check-circle class="mb-2 size-8 text-green-500" />
+                <div class="flex flex-1 flex-col items-center justify-center py-10 text-center">
+                    <div class="mb-3 rounded-full bg-green-50 p-3 dark:bg-green-900/20">
+                        <flux:icon.check-circle class="size-8 text-green-500" />
+                    </div>
                     <flux:text class="text-zinc-500">{{ __('All products are sufficiently stocked.') }}</flux:text>
                 </div>
             @else
                 <div class="flex flex-col gap-2">
                     @foreach($this->lowStockProducts as $product)
-                        <div class="flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/40 dark:bg-red-900/10">
-                            <div>
-                                <flux:text class="font-medium text-zinc-800 dark:text-zinc-100">{{ $product->name }}</flux:text>
-                                <flux:text class="text-xs text-zinc-500">{{ $product->category->name }} · SKU: {{ $product->sku }}</flux:text>
+                        <div class="flex items-center justify-between rounded-lg border border-red-100 bg-red-50 px-4 py-3 dark:border-red-900/30 dark:bg-red-900/10">
+                            <div class="min-w-0">
+                                <p class="truncate font-medium text-zinc-900 dark:text-zinc-100">{{ $product->name }}</p>
+                                <p class="text-xs text-zinc-400">{{ $product->category->name }} · {{ $product->sku }}</p>
                             </div>
-                            <div class="text-end">
-                                <flux:badge variant="danger">{{ $product->totalStock() }} / {{ $product->min_stock }}</flux:badge>
-                                <flux:text class="mt-0.5 text-xs text-zinc-400">{{ __('stock / min') }}</flux:text>
+                            <div class="ml-3 shrink-0 text-end">
+                                <span class="text-lg font-bold text-red-600 dark:text-red-400">{{ $product->totalStock() }}</span>
+                                <span class="text-sm text-zinc-400"> / {{ $product->min_stock }}</span>
+                                <p class="text-xs text-zinc-400">{{ __('stock / min') }}</p>
                             </div>
                         </div>
                     @endforeach
                 </div>
+                @if($isAdmin)
+                    <flux:button :href="route('stock.movements.create')" wire:navigate variant="filled" size="sm" icon="plus" class="mt-1 self-start">
+                        {{ __('Register Incoming') }}
+                    </flux:button>
+                @endif
             @endif
-        </flux:card>
+        </div>
 
         {{-- Recent Activity --}}
-        <flux:card class="flex flex-col gap-4">
-            <flux:heading>{{ __('Recent Activity') }}</flux:heading>
+        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="flex items-center gap-2">
+                <flux:icon.clock class="size-5 text-zinc-400" />
+                <flux:heading>{{ __('Recent Activity') }}</flux:heading>
+            </div>
 
             @if($this->recentActivity->isEmpty())
-                <div class="flex flex-1 flex-col items-center justify-center py-8 text-center">
-                    <flux:icon.clock class="mb-2 size-8 text-zinc-400" />
+                <div class="flex flex-1 flex-col items-center justify-center py-10 text-center">
+                    <div class="mb-3 rounded-full bg-zinc-50 p-3 dark:bg-zinc-800">
+                        <flux:icon.clock class="size-8 text-zinc-400" />
+                    </div>
                     <flux:text class="text-zinc-500">{{ __('No activity yet.') }}</flux:text>
                 </div>
             @else
-                <div class="flex flex-col gap-2">
+                <div class="flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800">
                     @foreach($this->recentActivity as $activity)
-                        <div class="flex items-start gap-3">
+                        <div class="flex items-start gap-3 py-3 first:pt-0 last:pb-0">
                             <flux:avatar
                                 size="sm"
                                 :name="$activity->causer?->name ?? 'System'"
-                                :initials="$activity->causer?->initials() ?? 'SY'"
                                 class="mt-0.5 shrink-0"
                             />
                             <div class="min-w-0 flex-1">
-                                <flux:text class="text-sm">
-                                    <span class="font-medium">{{ $activity->causer?->name ?? __('System') }}</span>
-                                    {{ $activity->description }}
-                                    <span class="font-medium">{{ class_basename($activity->subject_type ?? '') }}</span>
-                                </flux:text>
-                                <flux:text class="text-xs text-zinc-400">{{ $activity->created_at->diffForHumans() }}</flux:text>
+                                <p class="text-sm text-zinc-700 dark:text-zinc-300">
+                                    <span class="font-semibold">{{ $activity->causer?->name ?? __('System') }}</span>
+                                    <span class="text-zinc-500"> {{ $activity->description }} </span>
+                                    <span class="font-medium text-zinc-600 dark:text-zinc-400">{{ class_basename($activity->subject_type ?? '') }}</span>
+                                </p>
+                                <p class="text-xs text-zinc-400">{{ $activity->created_at->diffForHumans() }}</p>
                             </div>
                         </div>
                     @endforeach
                 </div>
             @endif
-        </flux:card>
+        </div>
 
     </div>
 

--- a/resources/views/livewire/deliveries/index.blade.php
+++ b/resources/views/livewire/deliveries/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Deliveries') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Deliveries') }}</flux:heading>
+            <flux:subheading>{{ __('Incoming deliveries and their processing status') }}</flux:subheading>
+        </div>
         @if(auth()->user()->isAdmin())
             <flux:button :href="route('deliveries.create')" wire:navigate variant="primary" icon="plus">
                 {{ __('New Delivery') }}
@@ -78,8 +81,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="7" class="py-12 text-center">
-                        {{ $filterStatus ? __('No deliveries with this status.') : __('No deliveries yet.') }}
+                    <flux:table.cell colspan="7" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.inbox-arrow-down class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $filterStatus ? __('No deliveries with this status.') : __('No deliveries yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/deliveries/show.blade.php
+++ b/resources/views/livewire/deliveries/show.blade.php
@@ -1,36 +1,78 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
-    {{-- Header --}}
-    <div class="flex items-center gap-4">
-        <flux:button :href="route('deliveries.index')" wire:navigate variant="ghost" icon="arrow-left" />
-        <div>
-            <flux:heading size="xl">
-                {{ __('Delivery') }} {{ $delivery->reference ? "— {$delivery->reference}" : "#{$delivery->id}" }}
-            </flux:heading>
-            <flux:subheading>{{ $delivery->supplier->name }} · {{ $delivery->created_at->format('d/m/Y') }}</flux:subheading>
+    {{-- Back + Header --}}
+    <div>
+        <flux:button :href="route('deliveries.index')" wire:navigate variant="ghost" icon="arrow-left" size="sm" class="mb-4">
+            {{ __('All Deliveries') }}
+        </flux:button>
+
+        <div class="flex flex-wrap items-start justify-between gap-4">
+            <div class="flex items-center gap-4">
+                @php
+                    $statusVariant = match($delivery->status->value) {
+                        'received' => 'success',
+                        'partial'  => 'warning',
+                        default    => 'outline',
+                    };
+                    $statusIcon = match($delivery->status->value) {
+                        'received' => 'check-circle',
+                        'partial'  => 'clock',
+                        default    => 'inbox',
+                    };
+                @endphp
+                <div class="rounded-xl bg-zinc-100 p-3 dark:bg-zinc-800">
+                    <flux:icon.inbox-arrow-down class="size-7 text-zinc-600 dark:text-zinc-300" />
+                </div>
+                <div>
+                    <div class="flex items-center gap-2">
+                        <flux:heading size="xl">
+                            {{ $delivery->reference ?? __('Delivery') . ' #' . $delivery->id }}
+                        </flux:heading>
+                        <flux:badge variant="{{ $statusVariant }}" icon="{{ $statusIcon }}">{{ ucfirst($delivery->status->value) }}</flux:badge>
+                    </div>
+                    <p class="mt-0.5 text-sm text-zinc-500">
+                        <span class="font-medium">{{ $delivery->supplier->name }}</span>
+                        <span class="mx-1.5 text-zinc-300 dark:text-zinc-600">·</span>
+                        {{ $delivery->created_at->format('d/m/Y') }}
+                        <span class="mx-1.5 text-zinc-300 dark:text-zinc-600">·</span>
+                        {{ __('Created by') }} {{ $delivery->user->name }}
+                    </p>
+                </div>
+            </div>
+
+            {{-- Progress summary --}}
+            @php
+                $totalOrdered  = $delivery->items->sum('quantity_ordered');
+                $totalReceived = $delivery->items->sum('quantity_received');
+                $pct = $totalOrdered > 0 ? round(($totalReceived / $totalOrdered) * 100) : 0;
+            @endphp
+            <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-5 py-3 dark:border-zinc-700 dark:bg-zinc-900">
+                <div>
+                    <p class="text-right text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $pct }}%</p>
+                    <p class="text-xs text-zinc-500">{{ __('received') }}</p>
+                </div>
+                <div class="h-10 w-px bg-zinc-200 dark:bg-zinc-700"></div>
+                <div class="text-sm">
+                    <p><span class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $totalReceived }}</span> <span class="text-zinc-500">/ {{ $totalOrdered }}</span></p>
+                    <p class="text-zinc-500">{{ __('units') }}</p>
+                </div>
+            </div>
         </div>
-        @php
-            $statusVariant = match($delivery->status->value) {
-                'received' => 'success',
-                'partial' => 'warning',
-                default => 'outline',
-            };
-        @endphp
-        <flux:badge variant="{{ $statusVariant }}" class="ml-2">{{ ucfirst($delivery->status->value) }}</flux:badge>
     </div>
 
-    <div class="flex max-w-3xl flex-col gap-6">
+    <div class="flex max-w-4xl flex-col gap-6">
 
-        {{-- Meta --}}
+        {{-- Notes --}}
         @if($delivery->notes)
-            <flux:card>
-                <flux:text class="text-sm text-zinc-500">{{ $delivery->notes }}</flux:text>
-            </flux:card>
+            <div class="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/40 dark:bg-amber-900/10">
+                <flux:icon.information-circle class="mt-0.5 size-5 shrink-0 text-amber-600 dark:text-amber-400" />
+                <p class="text-sm text-amber-800 dark:text-amber-300">{{ $delivery->notes }}</p>
+            </div>
         @endif
 
-        {{-- Items --}}
+        {{-- Items table --}}
         <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
-            <flux:heading size="lg">{{ __('Items') }}</flux:heading>
+            <flux:heading size="lg">{{ __('Delivery Items') }}</flux:heading>
 
             <flux:table>
                 <flux:table.columns>
@@ -45,29 +87,34 @@
 
                 <flux:table.rows>
                     @foreach ($delivery->items as $item)
+                        @php $remaining = $item->quantity_ordered - $item->quantity_received; @endphp
                         <flux:table.row :key="$item->id">
                             <flux:table.cell variant="strong">
                                 {{ $item->product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $item->product->sku }}</div>
+                                <div class="text-xs font-mono font-normal text-zinc-400">{{ $item->product->sku }}</div>
                             </flux:table.cell>
 
                             <flux:table.cell class="text-sm">
-                                {{ $item->location->warehouse->name }} — {{ $item->location->code }}
+                                <div class="flex items-center gap-1.5">
+                                    <flux:icon.building-office class="size-3.5 text-zinc-400" />
+                                    <span class="text-zinc-500">{{ $item->location->warehouse->name }}</span>
+                                    <span class="text-zinc-300 dark:text-zinc-600">·</span>
+                                    <span class="font-mono font-medium">{{ $item->location->code }}</span>
+                                </div>
                             </flux:table.cell>
 
                             <flux:table.cell>
-                                {{ $item->quantity_ordered }}
+                                <span class="font-medium">{{ $item->quantity_ordered }}</span>
                             </flux:table.cell>
 
                             <flux:table.cell>
-                                <span class="{{ $item->quantity_received >= $item->quantity_ordered ? 'text-green-600 dark:text-green-400' : '' }} font-medium">
+                                <span class="font-semibold {{ $item->quantity_received >= $item->quantity_ordered ? 'text-emerald-600 dark:text-emerald-400' : '' }}">
                                     {{ $item->quantity_received }}
                                 </span>
                             </flux:table.cell>
 
                             @if($delivery->status !== \App\Enums\DeliveryStatus::Received)
                                 <flux:table.cell>
-                                    @php $remaining = $item->quantity_ordered - $item->quantity_received; @endphp
                                     @if($remaining > 0)
                                         <flux:input
                                             wire:model="receivedQuantities.{{ $item->id }}"
@@ -77,7 +124,7 @@
                                             class="w-24"
                                         />
                                     @else
-                                        <flux:badge variant="success">{{ __('Done') }}</flux:badge>
+                                        <flux:badge variant="success" icon="check">{{ __('Done') }}</flux:badge>
                                     @endif
                                 </flux:table.cell>
                             @endif
@@ -87,7 +134,7 @@
             </flux:table>
 
             @if($delivery->status !== \App\Enums\DeliveryStatus::Received)
-                <div class="flex justify-end">
+                <div class="flex justify-end pt-2">
                     <flux:button
                         wire:click="process"
                         wire:confirm="{{ __('Process this delivery and update stock?') }}"
@@ -98,10 +145,10 @@
                     </flux:button>
                 </div>
             @else
-                <flux:text class="text-sm text-zinc-400">
+                <p class="text-sm text-zinc-400">
                     {{ __('Fully received on') }} {{ $delivery->received_at?->format('d/m/Y H:i') }}
                     {{ __('by') }} {{ $delivery->user->name }}.
-                </flux:text>
+                </p>
             @endif
         </div>
 

--- a/resources/views/livewire/locations/index.blade.php
+++ b/resources/views/livewire/locations/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Locations') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Locations') }}</flux:heading>
+            <flux:subheading>{{ __('Storage positions within your warehouses') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Location') }}
         </flux:button>
@@ -42,7 +45,7 @@
             @forelse ($this->locations as $location)
                 <flux:table.row :key="$location->id">
                     <flux:table.cell variant="strong">
-                        <flux:badge>{{ $location->code }}</flux:badge>
+                        <span class="rounded-md bg-zinc-100 px-2.5 py-1 font-mono text-sm font-semibold text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">{{ $location->code }}</span>
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -86,8 +89,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
-                        {{ $search || $filterWarehouse ? __('No locations match your filters.') : __('No locations yet.') }}
+                    <flux:table.cell colspan="6" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.map-pin class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $search || $filterWarehouse ? __('No locations match your filters.') : __('No locations yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Products') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Products') }}</flux:heading>
+            <flux:subheading>{{ __('Manage your product catalogue, SKUs and categories') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Product') }}
         </flux:button>

--- a/resources/views/livewire/reports/index.blade.php
+++ b/resources/views/livewire/reports/index.blade.php
@@ -1,29 +1,35 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
     {{-- Header --}}
-    <flux:heading size="xl">{{ __('Reports') }}</flux:heading>
+    <div>
+        <flux:heading size="xl">{{ __('Reports') }}</flux:heading>
+        <flux:subheading>{{ __('Insights into stock levels, locations and movement history') }}</flux:subheading>
+    </div>
 
     {{-- Tabs --}}
     <div class="flex gap-1 border-b border-zinc-200 dark:border-zinc-700">
         <button
             wire:click="setTab('low-stock')"
-            class="px-4 py-2 text-sm font-medium transition {{ $tab === 'low-stock' ? 'border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
+            class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'low-stock' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
         >
+            <flux:icon.exclamation-triangle class="size-4" />
             {{ __('Low Stock') }}
-            @if($tab === 'low-stock' && $this->lowStockProducts->isNotEmpty())
-                <flux:badge variant="danger" size="sm" class="ml-1">{{ $this->lowStockProducts->count() }}</flux:badge>
+            @if($this->lowStockProducts->isNotEmpty())
+                <flux:badge variant="danger" size="sm">{{ $this->lowStockProducts->count() }}</flux:badge>
             @endif
         </button>
         <button
             wire:click="setTab('stock-per-location')"
-            class="px-4 py-2 text-sm font-medium transition {{ $tab === 'stock-per-location' ? 'border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
+            class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'stock-per-location' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
         >
+            <flux:icon.map-pin class="size-4" />
             {{ __('Stock per Location') }}
         </button>
         <button
             wire:click="setTab('movements')"
-            class="px-4 py-2 text-sm font-medium transition {{ $tab === 'movements' ? 'border-b-2 border-zinc-900 text-zinc-900 dark:border-zinc-100 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
+            class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'movements' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"
         >
+            <flux:icon.arrow-path class="size-4" />
             {{ __('Movements per Period') }}
         </button>
     </div>
@@ -31,43 +37,39 @@
     {{-- TAB: Low Stock --}}
     @if($tab === 'low-stock')
         @if($this->lowStockProducts->isEmpty())
-            <div class="flex flex-1 flex-col items-center justify-center py-16 text-center">
-                <flux:icon.check-circle class="mb-3 size-10 text-green-500" />
+            <div class="flex flex-1 flex-col items-center justify-center py-20 text-center">
+                <div class="mb-3 rounded-full bg-green-50 p-4 dark:bg-green-900/20">
+                    <flux:icon.check-circle class="size-10 text-green-500" />
+                </div>
                 <flux:heading>{{ __('All products are sufficiently stocked.') }}</flux:heading>
                 <flux:text class="text-zinc-400">{{ __('No products are currently below their minimum stock level.') }}</flux:text>
             </div>
         @else
-            <flux:table>
-                <flux:table.columns>
-                    <flux:table.column>{{ __('Product') }}</flux:table.column>
-                    <flux:table.column>{{ __('Category') }}</flux:table.column>
-                    <flux:table.column>{{ __('Current Stock') }}</flux:table.column>
-                    <flux:table.column>{{ __('Minimum') }}</flux:table.column>
-                    <flux:table.column>{{ __('Shortage') }}</flux:table.column>
-                    <flux:table.column>{{ __('Locations') }}</flux:table.column>
-                </flux:table.columns>
-                <flux:table.rows>
-                    @foreach($this->lowStockProducts as $product)
-                        <flux:table.row :key="$product->id">
-                            <flux:table.cell variant="strong">
-                                {{ $product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $product->sku }}</div>
-                            </flux:table.cell>
-                            <flux:table.cell>{{ $product->category?->name ?? '—' }}</flux:table.cell>
-                            <flux:table.cell>
-                                <span class="font-medium text-red-600 dark:text-red-400">{{ $product->totalStock() }}</span>
-                            </flux:table.cell>
-                            <flux:table.cell>{{ $product->min_stock }}</flux:table.cell>
-                            <flux:table.cell>
-                                <flux:badge variant="danger">{{ $product->totalStock() - $product->min_stock }}</flux:badge>
-                            </flux:table.cell>
-                            <flux:table.cell class="text-sm text-zinc-500">
-                                {{ $product->stock->map(fn($s) => $s->location->code)->join(', ') ?: '—' }}
-                            </flux:table.cell>
-                        </flux:table.row>
-                    @endforeach
-                </flux:table.rows>
-            </flux:table>
+            <div class="flex flex-col gap-3">
+                @foreach($this->lowStockProducts as $product)
+                    <div class="flex items-center justify-between rounded-xl border border-red-200 bg-red-50 px-5 py-4 dark:border-red-900/40 dark:bg-red-900/10">
+                        <div class="flex items-center gap-4">
+                            <div class="rounded-lg bg-red-100 p-2 dark:bg-red-900/30">
+                                <flux:icon.exclamation-triangle class="size-5 text-red-600 dark:text-red-400" />
+                            </div>
+                            <div>
+                                <p class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $product->name }}</p>
+                                <p class="text-xs text-zinc-500">{{ $product->category?->name ?? '—' }} · <span class="font-mono">{{ $product->sku }}</span></p>
+                                @if($product->stock->isNotEmpty())
+                                    <p class="mt-0.5 text-xs text-zinc-400">
+                                        {{ __('Locations:') }} {{ $product->stock->map(fn($s) => $s->location->code)->join(', ') }}
+                                    </p>
+                                @endif
+                            </div>
+                        </div>
+                        <div class="text-right">
+                            <p class="text-2xl font-bold text-red-600 dark:text-red-400">{{ $product->totalStock() }}<span class="text-sm font-normal text-zinc-400"> / {{ $product->min_stock }}</span></p>
+                            <p class="text-xs text-zinc-500">{{ __('stock / minimum') }}</p>
+                            <flux:badge variant="danger" class="mt-1">{{ __('shortage:') }} {{ $product->totalStock() - $product->min_stock }}</flux:badge>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
         @endif
     @endif
 
@@ -82,13 +84,14 @@
                     @endforeach
                 </flux:select>
             </div>
-            <flux:text class="text-sm text-zinc-400">
-                {{ $this->stockPerLocation->count() }} {{ __('lines') }}
-            </flux:text>
+            <span class="text-sm text-zinc-400">{{ $this->stockPerLocation->count() }} {{ __('lines') }}</span>
         </div>
 
         @if($this->stockPerLocation->isEmpty())
-            <flux:text class="py-12 text-center text-zinc-400">{{ __('No stock registered yet.') }}</flux:text>
+            <div class="flex flex-col items-center justify-center py-16 text-center">
+                <flux:icon.cube class="mb-2 size-10 text-zinc-300" />
+                <flux:text class="text-zinc-400">{{ __('No stock registered yet.') }}</flux:text>
+            </div>
         @else
             <flux:table>
                 <flux:table.columns>
@@ -101,17 +104,22 @@
                 <flux:table.rows>
                     @foreach($this->stockPerLocation as $line)
                         <flux:table.row :key="$line->id">
-                            <flux:table.cell>{{ $line->location->warehouse->name }}</flux:table.cell>
                             <flux:table.cell>
-                                <flux:badge>{{ $line->location->code }}</flux:badge>
+                                <div class="flex items-center gap-1.5 text-sm">
+                                    <flux:icon.building-office class="size-4 text-zinc-400" />
+                                    {{ $line->location->warehouse->name }}
+                                </div>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <span class="rounded bg-zinc-100 px-2 py-0.5 font-mono text-xs font-semibold dark:bg-zinc-800">{{ $line->location->code }}</span>
                             </flux:table.cell>
                             <flux:table.cell variant="strong">
                                 {{ $line->product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $line->product->sku }}</div>
+                                <div class="font-mono text-xs font-normal text-zinc-400">{{ $line->product->sku }}</div>
                             </flux:table.cell>
                             <flux:table.cell>{{ $line->product->category?->name ?? '—' }}</flux:table.cell>
                             <flux:table.cell>
-                                <span class="font-medium">{{ $line->quantity }}</span>
+                                <span class="text-lg font-bold text-zinc-900 dark:text-zinc-100">{{ $line->quantity }}</span>
                             </flux:table.cell>
                         </flux:table.row>
                     @endforeach
@@ -122,7 +130,7 @@
 
     {{-- TAB: Movements per Period --}}
     @if($tab === 'movements')
-        <div class="flex flex-wrap items-center gap-3">
+        <div class="flex flex-wrap items-end gap-3">
             <flux:field>
                 <flux:label>{{ __('From') }}</flux:label>
                 <flux:input wire:model.live="filterFrom" type="date" />
@@ -140,13 +148,14 @@
                     @endforeach
                 </flux:select>
             </flux:field>
-            <flux:text class="mt-5 text-sm text-zinc-400">
-                {{ $this->movements->count() }} {{ __('movements') }}
-            </flux:text>
+            <p class="mb-2 text-sm text-zinc-400">{{ $this->movements->count() }} {{ __('movements') }}</p>
         </div>
 
         @if($this->movements->isEmpty())
-            <flux:text class="py-12 text-center text-zinc-400">{{ __('No movements found for this period.') }}</flux:text>
+            <div class="flex flex-col items-center justify-center py-16 text-center">
+                <flux:icon.arrow-path class="mb-2 size-10 text-zinc-300" />
+                <flux:text class="text-zinc-400">{{ __('No movements found for this period.') }}</flux:text>
+            </div>
         @else
             <flux:table>
                 <flux:table.columns>
@@ -163,18 +172,20 @@
                         <flux:table.row :key="$movement->id">
                             <flux:table.cell variant="strong">
                                 {{ $movement->product->name }}
-                                <div class="text-xs font-normal text-zinc-400">{{ $movement->product->sku }}</div>
+                                <div class="font-mono text-xs font-normal text-zinc-400">{{ $movement->product->sku }}</div>
                             </flux:table.cell>
                             <flux:table.cell>
                                 @php
-                                    $v = match($movement->type->value) {
-                                        'incoming' => 'success', 'outgoing' => 'danger',
-                                        'transfer' => 'warning', default => 'outline',
+                                    [$v, $ico] = match($movement->type->value) {
+                                        'incoming'   => ['success', 'arrow-down-tray'],
+                                        'outgoing'   => ['danger', 'arrow-up-tray'],
+                                        'transfer'   => ['warning', 'arrows-right-left'],
+                                        default      => ['outline', 'pencil-square'],
                                     };
                                 @endphp
-                                <flux:badge variant="{{ $v }}">{{ ucfirst($movement->type->value) }}</flux:badge>
+                                <flux:badge variant="{{ $v }}" icon="{{ $ico }}">{{ ucfirst($movement->type->value) }}</flux:badge>
                             </flux:table.cell>
-                            <flux:table.cell class="text-sm">
+                            <flux:table.cell class="font-mono text-sm">
                                 @if($movement->type->value === 'transfer')
                                     {{ $movement->fromLocation?->code }} → {{ $movement->toLocation?->code }}
                                 @else
@@ -182,7 +193,7 @@
                                 @endif
                             </flux:table.cell>
                             <flux:table.cell>
-                                <span class="{{ $movement->quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }} font-medium">
+                                <span class="font-bold {{ $movement->quantity > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400' }}">
                                     {{ $movement->quantity > 0 ? '+' : '' }}{{ $movement->quantity }}
                                 </span>
                             </flux:table.cell>

--- a/resources/views/livewire/stock/index.blade.php
+++ b/resources/views/livewire/stock/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Stock Overview') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Stock Overview') }}</flux:heading>
+            <flux:subheading>{{ __('Current stock levels per product and location') }}</flux:subheading>
+        </div>
         <flux:button :href="route('stock.movements.create')" wire:navigate variant="primary" icon="plus">
             {{ __('Register Movement') }}
         </flux:button>
@@ -30,6 +33,7 @@
     {{-- Table --}}
     <flux:table>
         <flux:table.columns>
+            <flux:table.column></flux:table.column>
             <flux:table.column>{{ __('Product') }}</flux:table.column>
             <flux:table.column>{{ __('SKU') }}</flux:table.column>
             <flux:table.column>{{ __('Category') }}</flux:table.column>
@@ -40,39 +44,98 @@
 
         <flux:table.rows>
             @forelse ($this->stockLines as $product)
+                @php
+                    $totalQty   = $product->stock->sum('quantity');
+                    $belowMin   = $product->min_stock > 0 && $totalQty < $product->min_stock;
+                    $rowClass   = $belowMin ? 'bg-red-50/60 dark:bg-red-900/5' : '';
+                @endphp
+
                 @if ($product->stock->isEmpty())
-                    <flux:table.row :key="'p-'.$product->id">
+                    <flux:table.row :key="'p-'.$product->id" class="{{ $rowClass }}">
+                        {{-- Image --}}
+                        <flux:table.cell>
+                            @if ($product->image_path)
+                                <img src="{{ Storage::url($product->image_path) }}" alt="{{ $product->name }}" class="size-9 rounded-lg object-cover" />
+                            @else
+                                <div class="flex size-9 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800">
+                                    <flux:icon.photo class="size-4 text-zinc-400" />
+                                </div>
+                            @endif
+                        </flux:table.cell>
                         <flux:table.cell variant="strong">{{ $product->name }}</flux:table.cell>
                         <flux:table.cell><flux:badge>{{ $product->sku }}</flux:badge></flux:table.cell>
                         <flux:table.cell>{{ $product->category?->name ?? '—' }}</flux:table.cell>
-                        <flux:table.cell class="text-zinc-400">{{ __('No stock registered') }}</flux:table.cell>
-                        <flux:table.cell>0</flux:table.cell>
+                        <flux:table.cell class="text-zinc-400 italic">{{ __('No stock registered') }}</flux:table.cell>
+                        <flux:table.cell>
+                            <span class="font-bold text-zinc-400">0</span>
+                        </flux:table.cell>
                         <flux:table.cell>
                             @if($product->min_stock > 0)
-                                <flux:badge variant="danger">{{ __('Below minimum') }}</flux:badge>
+                                <flux:badge variant="danger" icon="exclamation-triangle">{{ __('Below minimum') }}</flux:badge>
+                            @else
+                                <flux:badge variant="outline">{{ __('No minimum') }}</flux:badge>
                             @endif
                         </flux:table.cell>
                     </flux:table.row>
                 @else
-                    @foreach ($product->stock as $stockLine)
-                        <flux:table.row :key="'s-'.$stockLine->id">
-                            <flux:table.cell variant="strong">{{ $product->name }}</flux:table.cell>
-                            <flux:table.cell><flux:badge>{{ $product->sku }}</flux:badge></flux:table.cell>
-                            <flux:table.cell>{{ $product->category?->name ?? '—' }}</flux:table.cell>
+                    @foreach ($product->stock as $i => $stockLine)
+                        <flux:table.row :key="'s-'.$stockLine->id" class="{{ $rowClass }}">
+                            {{-- Image only on first row --}}
                             <flux:table.cell>
-                                <span class="text-sm">
-                                    {{ $stockLine->location->warehouse->name }} —
-                                    <span class="font-medium">{{ $stockLine->location->code }}</span>
+                                @if ($i === 0)
+                                    @if ($product->image_path)
+                                        <img src="{{ Storage::url($product->image_path) }}" alt="{{ $product->name }}" class="size-9 rounded-lg object-cover" />
+                                    @else
+                                        <div class="flex size-9 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800">
+                                            <flux:icon.photo class="size-4 text-zinc-400" />
+                                        </div>
+                                    @endif
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell variant="strong">
+                                @if ($i === 0)
+                                    {{ $product->name }}
+                                    @if ($product->stock->count() > 1)
+                                        <span class="ml-1 text-xs font-normal text-zinc-400">({{ $product->stock->count() }} {{ __('locations') }})</span>
+                                    @endif
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                @if ($i === 0)
+                                    <flux:badge>{{ $product->sku }}</flux:badge>
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                @if ($i === 0)
+                                    {{ $product->category?->name ?? '—' }}
+                                @endif
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                <div class="flex items-center gap-1.5 text-sm">
+                                    <flux:icon.building-office class="size-3.5 text-zinc-400" />
+                                    <span class="text-zinc-500">{{ $stockLine->location->warehouse->name }}</span>
+                                    <span class="text-zinc-300 dark:text-zinc-600">·</span>
+                                    <span class="font-medium font-mono">{{ $stockLine->location->code }}</span>
+                                </div>
+                            </flux:table.cell>
+
+                            <flux:table.cell>
+                                <span class="text-lg font-bold {{ $belowMin && $i === 0 ? 'text-red-600 dark:text-red-400' : 'text-zinc-900 dark:text-zinc-100' }}">
+                                    {{ $stockLine->quantity }}
                                 </span>
                             </flux:table.cell>
+
                             <flux:table.cell>
-                                <span class="font-medium">{{ $stockLine->quantity }}</span>
-                            </flux:table.cell>
-                            <flux:table.cell>
-                                @if ($product->min_stock > 0 && $product->totalStock() < $product->min_stock)
-                                    <flux:badge variant="danger">{{ __('Below minimum') }}</flux:badge>
-                                @else
-                                    <flux:badge variant="success">{{ __('OK') }}</flux:badge>
+                                @if ($i === 0)
+                                    @if ($belowMin)
+                                        <flux:badge variant="danger" icon="exclamation-triangle">{{ __('Below minimum') }}</flux:badge>
+                                    @else
+                                        <flux:badge variant="success" icon="check">{{ __('OK') }}</flux:badge>
+                                    @endif
                                 @endif
                             </flux:table.cell>
                         </flux:table.row>
@@ -80,8 +143,13 @@
                 @endif
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
-                        {{ $search || $filterWarehouse ? __('No products match your filters.') : __('No products found.') }}
+                    <flux:table.cell colspan="7" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.cube class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">
+                                {{ $search || $filterWarehouse ? __('No products match your filters.') : __('No products found.') }}
+                            </span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/stock/movements.blade.php
+++ b/resources/views/livewire/stock/movements.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Stock Movements') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Stock Movements') }}</flux:heading>
+            <flux:subheading>{{ __('Full history of all incoming, outgoing, transfer and correction events') }}</flux:subheading>
+        </div>
         <flux:button :href="route('stock.movements.create')" wire:navigate variant="primary" icon="plus">
             {{ __('Register Movement') }}
         </flux:button>
@@ -44,33 +47,43 @@
                 <flux:table.row :key="$movement->id">
                     <flux:table.cell variant="strong">
                         {{ $movement->product->name }}
-                        <div class="text-xs font-normal text-zinc-400">{{ $movement->product->sku }}</div>
+                        <div class="text-xs font-mono font-normal text-zinc-400">{{ $movement->product->sku }}</div>
                     </flux:table.cell>
 
                     <flux:table.cell>
                         @php
-                            $typeVariant = match($movement->type->value) {
-                                'incoming' => 'success',
-                                'outgoing' => 'danger',
-                                'transfer' => 'warning',
-                                'correction' => 'outline',
-                                default => 'outline',
+                            [$variant, $icon] = match($movement->type->value) {
+                                'incoming'   => ['success', 'arrow-down-tray'],
+                                'outgoing'   => ['danger', 'arrow-up-tray'],
+                                'transfer'   => ['warning', 'arrows-right-left'],
+                                'correction' => ['outline', 'pencil-square'],
+                                default      => ['outline', 'question-mark-circle'],
                             };
                         @endphp
-                        <flux:badge variant="{{ $typeVariant }}">{{ ucfirst($movement->type->value) }}</flux:badge>
+                        <flux:badge variant="{{ $variant }}" icon="{{ $icon }}">{{ ucfirst($movement->type->value) }}</flux:badge>
                     </flux:table.cell>
 
                     <flux:table.cell class="text-sm">
                         @if ($movement->type->value === 'transfer')
-                            <span class="text-zinc-500">{{ $movement->fromLocation?->code }}</span>
-                            → {{ $movement->toLocation?->code }}
+                            <span class="flex items-center gap-1">
+                                <span class="font-mono font-medium">{{ $movement->fromLocation?->code ?? '—' }}</span>
+                                <flux:icon.arrow-right class="size-3 text-zinc-400" />
+                                <span class="font-mono font-medium">{{ $movement->toLocation?->code ?? '—' }}</span>
+                            </span>
                         @else
-                            {{ $movement->location?->code ?? '—' }}
+                            <span class="font-mono font-medium">{{ $movement->location?->code ?? '—' }}</span>
                         @endif
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        <span class="{{ $movement->quantity > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }} font-medium">
+                        @php
+                            $qtyClass = match(true) {
+                                $movement->quantity > 0  => 'text-emerald-600 dark:text-emerald-400',
+                                $movement->quantity < 0  => 'text-red-600 dark:text-red-400',
+                                default                  => 'text-zinc-500',
+                            };
+                        @endphp
+                        <span class="text-base font-bold {{ $qtyClass }}">
                             {{ $movement->quantity > 0 ? '+' : '' }}{{ $movement->quantity }}
                         </span>
                     </flux:table.cell>
@@ -79,18 +92,28 @@
                         {{ $movement->reference ?? '—' }}
                     </flux:table.cell>
 
-                    <flux:table.cell class="text-sm">
-                        {{ $movement->user->name }}
+                    <flux:table.cell>
+                        <div class="flex items-center gap-2">
+                            <flux:avatar size="xs" :name="$movement->user->name" />
+                            <span class="text-sm">{{ $movement->user->name }}</span>
+                        </div>
                     </flux:table.cell>
 
                     <flux:table.cell class="text-sm text-zinc-400">
-                        {{ $movement->created_at->diffForHumans() }}
+                        <span title="{{ $movement->created_at->format('d/m/Y H:i') }}">
+                            {{ $movement->created_at->diffForHumans() }}
+                        </span>
                     </flux:table.cell>
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="7" class="py-12 text-center">
-                        {{ $search || $filterType ? __('No movements match your filters.') : __('No stock movements yet.') }}
+                    <flux:table.cell colspan="7" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.arrow-path class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">
+                                {{ $search || $filterType ? __('No movements match your filters.') : __('No stock movements yet.') }}
+                            </span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/suppliers/index.blade.php
+++ b/resources/views/livewire/suppliers/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Suppliers') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Suppliers') }}</flux:heading>
+            <flux:subheading>{{ __('Manage your product suppliers and their contact information') }}</flux:subheading>
+        </div>
         @if(auth()->user()->isAdmin())
             <flux:button wire:click="openCreate" variant="primary" icon="plus">
                 {{ __('New Supplier') }}
@@ -35,11 +38,18 @@
             @forelse ($this->suppliers as $supplier)
                 <flux:table.row :key="$supplier->id">
                     <flux:table.cell variant="strong">
-                        {{ $supplier->name }}
+                        <div class="flex items-center gap-3">
+                            <flux:avatar size="sm" :name="$supplier->name" />
+                            <span>{{ $supplier->name }}</span>
+                        </div>
                     </flux:table.cell>
 
                     <flux:table.cell>
-                        {{ $supplier->email ?? '—' }}
+                        @if($supplier->email)
+                            <a href="mailto:{{ $supplier->email }}" class="text-blue-600 hover:underline dark:text-blue-400">{{ $supplier->email }}</a>
+                        @else
+                            <span class="text-zinc-400">—</span>
+                        @endif
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -77,8 +87,11 @@
                 </flux:table.row>
             @empty
                 <flux:table.row>
-                    <flux:table.cell colspan="5" class="py-12 text-center">
-                        {{ $search ? __('No suppliers match your search.') : __('No suppliers yet.') }}
+                    <flux:table.cell colspan="5" class="py-16 text-center">
+                        <div class="flex flex-col items-center gap-2">
+                            <flux:icon.building-storefront class="size-10 text-zinc-300" />
+                            <span class="text-zinc-500">{{ $search ? __('No suppliers match your search.') : __('No suppliers yet.') }}</span>
+                        </div>
                     </flux:table.cell>
                 </flux:table.row>
             @endforelse

--- a/resources/views/livewire/warehouses/index.blade.php
+++ b/resources/views/livewire/warehouses/index.blade.php
@@ -2,7 +2,10 @@
 
     {{-- Header --}}
     <div class="flex items-center justify-between">
-        <flux:heading size="xl">{{ __('Warehouses') }}</flux:heading>
+        <div>
+            <flux:heading size="xl">{{ __('Warehouses') }}</flux:heading>
+            <flux:subheading>{{ __('Manage your warehouse locations and storage capacity') }}</flux:subheading>
+        </div>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New Warehouse') }}
         </flux:button>
@@ -17,84 +20,101 @@
         />
     </div>
 
-    {{-- Table --}}
-    <flux:table>
-        <flux:table.columns>
-            <flux:table.column>{{ __('Name') }}</flux:table.column>
-            <flux:table.column>{{ __('Location') }}</flux:table.column>
-            <flux:table.column>{{ __('Description') }}</flux:table.column>
-            <flux:table.column>{{ __('Locations') }}</flux:table.column>
-            <flux:table.column>{{ __('Created') }}</flux:table.column>
-            <flux:table.column></flux:table.column>
-        </flux:table.columns>
+    {{-- Card Grid --}}
+    @if ($this->warehouses->isEmpty())
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 py-20 text-center dark:border-zinc-700">
+            <div class="mb-3 rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
+                <flux:icon.building-office class="size-8 text-zinc-400" />
+            </div>
+            <flux:heading size="lg" class="mb-1">{{ __('No warehouses yet') }}</flux:heading>
+            <flux:text class="mb-4 text-zinc-500">{{ $search ? __('No warehouses match your search.') : __('Create your first warehouse to get started.') }}</flux:text>
+            @unless($search)
+                <flux:button wire:click="openCreate" variant="primary" icon="plus" size="sm">{{ __('New Warehouse') }}</flux:button>
+            @endunless
+        </div>
+    @else
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ($this->warehouses as $warehouse)
+                <div class="group relative flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 transition duration-200 hover:border-blue-300 hover:shadow-lg dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-700">
 
-        <flux:table.rows>
-            @forelse ($this->warehouses as $warehouse)
-                <flux:table.row :key="$warehouse->id">
-                    <flux:table.cell variant="strong">
-                        {{ $warehouse->name }}
-                    </flux:table.cell>
+                    {{-- Top row --}}
+                    <div class="flex items-start justify-between">
+                        <div class="flex items-center gap-3">
+                            <div class="rounded-lg bg-blue-50 p-2.5 dark:bg-blue-900/30">
+                                <flux:icon.building-office class="size-5 text-blue-600 dark:text-blue-400" />
+                            </div>
+                            <div>
+                                <p class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $warehouse->name }}</p>
+                                <p class="flex items-center gap-1 text-xs text-zinc-500">
+                                    <flux:icon.map-pin class="size-3" />
+                                    {{ $warehouse->location }}
+                                </p>
+                            </div>
+                        </div>
 
-                    <flux:table.cell>
-                        {{ $warehouse->location }}
-                    </flux:table.cell>
+                        {{-- Actions (above the link overlay) --}}
+                        <div class="relative z-10">
+                            <flux:dropdown>
+                                <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
+                                <flux:menu>
+                                    <flux:menu.item icon="eye" :href="route('warehouses.show', $warehouse)" wire:navigate>
+                                        {{ __('View') }}
+                                    </flux:menu.item>
+                                    <flux:menu.item icon="pencil" wire:click="openEdit({{ $warehouse->id }})">
+                                        {{ __('Edit') }}
+                                    </flux:menu.item>
+                                    <flux:menu.separator />
+                                    <flux:menu.item
+                                        icon="trash"
+                                        variant="danger"
+                                        wire:click="delete({{ $warehouse->id }})"
+                                        wire:confirm="{{ __('Delete this warehouse?') }}"
+                                    >
+                                        {{ __('Delete') }}
+                                    </flux:menu.item>
+                                </flux:menu>
+                            </flux:dropdown>
+                        </div>
+                    </div>
 
-                    <flux:table.cell>
-                        {{ $warehouse->description ?? '—' }}
-                    </flux:table.cell>
+                    {{-- Description --}}
+                    @if ($warehouse->description)
+                        <p class="line-clamp-2 text-sm text-zinc-500">{{ $warehouse->description }}</p>
+                    @else
+                        <p class="text-sm italic text-zinc-400">{{ __('No description') }}</p>
+                    @endif
 
-                    <flux:table.cell>
-                        <flux:badge variant="outline">{{ $warehouse->locations_count }}</flux:badge>
-                    </flux:table.cell>
+                    {{-- Stats --}}
+                    <div class="flex items-center gap-4 border-t border-zinc-100 pt-4 dark:border-zinc-800">
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.map-pin class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $warehouse->locations_count }}</span>
+                            <span class="text-zinc-400">{{ __('locations') }}</span>
+                        </div>
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.cube class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $warehouse->total_stock }}</span>
+                            <span class="text-zinc-400">{{ __('items') }}</span>
+                        </div>
+                    </div>
 
-                    <flux:table.cell>
-                        {{ $warehouse->created_at->diffForHumans() }}
-                    </flux:table.cell>
+                    {{-- Clickable overlay (behind the dropdown) --}}
+                    <a href="{{ route('warehouses.show', $warehouse) }}" wire:navigate class="absolute inset-0 rounded-xl"></a>
+                </div>
+            @endforeach
+        </div>
 
-                    <flux:table.cell align="end">
-                        <flux:dropdown>
-                            <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
-                            <flux:menu>
-                                <flux:menu.item
-                                    icon="pencil"
-                                    wire:click="openEdit({{ $warehouse->id }})"
-                                >
-                                    {{ __('Edit') }}
-                                </flux:menu.item>
-                                <flux:menu.separator />
-                                <flux:menu.item
-                                    icon="trash"
-                                    variant="danger"
-                                    wire:click="delete({{ $warehouse->id }})"
-                                    wire:confirm="{{ __('Delete this warehouse?') }}"
-                                >
-                                    {{ __('Delete') }}
-                                </flux:menu.item>
-                            </flux:menu>
-                        </flux:dropdown>
-                    </flux:table.cell>
-                </flux:table.row>
-            @empty
-                <flux:table.row>
-                    <flux:table.cell colspan="6" class="py-12 text-center">
-                        {{ $search ? __('No warehouses match your search.') : __('No warehouses yet.') }}
-                    </flux:table.cell>
-                </flux:table.row>
-            @endforelse
-        </flux:table.rows>
-    </flux:table>
-
-    {{-- Pagination --}}
-    <div>
-        {{ $this->warehouses->links() }}
-    </div>
+        {{-- Pagination --}}
+        <div>{{ $this->warehouses->links() }}</div>
+    @endif
 
     {{-- Create / Edit Modal --}}
     <flux:modal wire:model="showModal" class="max-w-md">
         <div class="flex flex-col gap-6 p-6">
-            <flux:heading size="lg">
-                {{ $editingId ? __('Edit Warehouse') : __('New Warehouse') }}
-            </flux:heading>
+            <div>
+                <flux:heading size="lg">{{ $editingId ? __('Edit Warehouse') : __('New Warehouse') }}</flux:heading>
+                <flux:subheading>{{ $editingId ? __('Update warehouse details') : __('Add a new warehouse to your network') }}</flux:subheading>
+            </div>
 
             <flux:field>
                 <flux:label>{{ __('Name') }}</flux:label>
@@ -104,7 +124,7 @@
 
             <flux:field>
                 <flux:label>{{ __('Location') }}</flux:label>
-                <flux:input wire:model="location" placeholder="{{ __('e.g. Brussels') }}" />
+                <flux:input wire:model="location" placeholder="{{ __('e.g. Brussels') }}" icon="map-pin" />
                 <flux:error name="location" />
             </flux:field>
 
@@ -115,12 +135,8 @@
             </flux:field>
 
             <div class="flex justify-end gap-3">
-                <flux:button wire:click="$set('showModal', false)" variant="ghost">
-                    {{ __('Cancel') }}
-                </flux:button>
-                <flux:button wire:click="save" variant="primary">
-                    {{ $editingId ? __('Update') : __('Create') }}
-                </flux:button>
+                <flux:button wire:click="$set('showModal', false)" variant="ghost">{{ __('Cancel') }}</flux:button>
+                <flux:button wire:click="save" variant="primary">{{ $editingId ? __('Update') : __('Create') }}</flux:button>
             </div>
         </div>
     </flux:modal>

--- a/resources/views/livewire/warehouses/show.blade.php
+++ b/resources/views/livewire/warehouses/show.blade.php
@@ -1,0 +1,154 @@
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+
+    {{-- Back + Header --}}
+    <div>
+        <flux:button :href="route('warehouses.index')" wire:navigate variant="ghost" icon="arrow-left" size="sm" class="mb-4">
+            {{ __('All Warehouses') }}
+        </flux:button>
+
+        <div class="flex items-start justify-between">
+            <div class="flex items-center gap-4">
+                <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
+                    <flux:icon.building-office class="size-7 text-blue-600 dark:text-blue-400" />
+                </div>
+                <div>
+                    <flux:heading size="xl">{{ $warehouse->name }}</flux:heading>
+                    <div class="mt-0.5 flex items-center gap-1.5 text-sm text-zinc-500">
+                        <flux:icon.map-pin class="size-4" />
+                        {{ $warehouse->location }}
+                    </div>
+                </div>
+            </div>
+            <flux:button wire:click="openCreateLocation" variant="primary" icon="plus">
+                {{ __('New Location') }}
+            </flux:button>
+        </div>
+
+        @if ($warehouse->description)
+            <p class="mt-3 max-w-2xl text-sm text-zinc-500">{{ $warehouse->description }}</p>
+        @endif
+    </div>
+
+    {{-- Stats bar --}}
+    <div class="grid grid-cols-3 gap-4">
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
+                <flux:icon.map-pin class="size-5 text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+                <p class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['location_count'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Locations') }}</p>
+            </div>
+        </div>
+
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-emerald-50 p-2 dark:bg-emerald-900/30">
+                <flux:icon.cube class="size-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <div>
+                <p class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['total_stock'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Total items in stock') }}</p>
+            </div>
+        </div>
+
+        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <flux:icon.tag class="size-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+                <p class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $this->stats['product_count'] }}</p>
+                <p class="text-xs text-zinc-500">{{ __('Distinct products') }}</p>
+            </div>
+        </div>
+    </div>
+
+    {{-- Locations --}}
+    @if ($this->locations->isEmpty())
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 py-20 text-center dark:border-zinc-700">
+            <div class="mb-3 rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
+                <flux:icon.map-pin class="size-8 text-zinc-400" />
+            </div>
+            <flux:heading size="lg" class="mb-1">{{ __('No locations yet') }}</flux:heading>
+            <flux:text class="mb-4 text-zinc-500">{{ __('Add storage locations to this warehouse.') }}</flux:text>
+            <flux:button wire:click="openCreateLocation" variant="primary" icon="plus" size="sm">{{ __('New Location') }}</flux:button>
+        </div>
+    @else
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            @foreach ($this->locations as $location)
+                <div class="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+
+                    {{-- Code + actions --}}
+                    <div class="flex items-start justify-between">
+                        <div>
+                            <span class="inline-flex items-center rounded-lg bg-zinc-100 px-2.5 py-1 text-sm font-mono font-semibold text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">
+                                {{ $location->code }}
+                            </span>
+                            @if ($location->name)
+                                <p class="mt-1 text-xs text-zinc-500">{{ $location->name }}</p>
+                            @endif
+                        </div>
+                        <flux:dropdown>
+                            <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
+                            <flux:menu>
+                                <flux:menu.item icon="pencil" wire:click="openEditLocation({{ $location->id }})">
+                                    {{ __('Edit') }}
+                                </flux:menu.item>
+                                <flux:menu.separator />
+                                <flux:menu.item
+                                    icon="trash"
+                                    variant="danger"
+                                    wire:click="deleteLocation({{ $location->id }})"
+                                    wire:confirm="{{ __('Delete this location?') }}"
+                                >
+                                    {{ __('Delete') }}
+                                </flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    </div>
+
+                    {{-- Stock stats --}}
+                    <div class="flex items-center gap-4 border-t border-zinc-100 pt-3 dark:border-zinc-800">
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.cube class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $location->total_stock }}</span>
+                            <span class="text-zinc-400">{{ __('items') }}</span>
+                        </div>
+                        <div class="flex items-center gap-1.5 text-sm">
+                            <flux:icon.tag class="size-4 text-zinc-400" />
+                            <span class="font-semibold text-zinc-800 dark:text-zinc-200">{{ $location->product_count }}</span>
+                            <span class="text-zinc-400">{{ __('SKUs') }}</span>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+
+    {{-- Add / Edit Location Modal --}}
+    <flux:modal wire:model="showModal" class="max-w-sm">
+        <div class="flex flex-col gap-6 p-6">
+            <div>
+                <flux:heading size="lg">{{ $editingLocationId ? __('Edit Location') : __('New Location') }}</flux:heading>
+                <flux:subheading>{{ $warehouse->name }}</flux:subheading>
+            </div>
+
+            <flux:field>
+                <flux:label>{{ __('Code') }}</flux:label>
+                <flux:input wire:model="code" placeholder="{{ __('e.g. A1') }}" class="uppercase" />
+                <flux:error name="code" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>{{ __('Name') }} <span class="text-xs font-normal text-zinc-400">({{ __('optional') }})</span></flux:label>
+                <flux:input wire:model="locationName" placeholder="{{ __('e.g. Ground shelf') }}" />
+                <flux:error name="locationName" />
+            </flux:field>
+
+            <div class="flex justify-end gap-3">
+                <flux:button wire:click="$set('showModal', false)" variant="ghost">{{ __('Cancel') }}</flux:button>
+                <flux:button wire:click="saveLocation" variant="primary">{{ $editingLocationId ? __('Update') : __('Create') }}</flux:button>
+            </div>
+        </div>
+    </flux:modal>
+
+</div>

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -1,14 +1,17 @@
 <x-layouts::auth :title="__('Log in')">
-    <div class="flex flex-col gap-6">
-        <x-auth-header :title="__('Log in to your account')" :description="__('Enter your email and password below to log in')" />
+    <div class="flex flex-col gap-5">
+
+        <div>
+            <h2 class="text-lg font-bold text-white">{{ __('Sign in') }}</h2>
+            <p class="mt-0.5 text-sm text-zinc-500">{{ __('Enter your credentials to access your account') }}</p>
+        </div>
 
         <!-- Session Status -->
-        <x-auth-session-status class="text-center" :status="session('status')" />
+        <x-auth-session-status :status="session('status')" />
 
-        <form method="POST" action="{{ route('login.store') }}" class="flex flex-col gap-6">
+        <form method="POST" action="{{ route('login.store') }}" class="flex flex-col gap-4">
             @csrf
 
-            <!-- Email Address -->
             <flux:input
                 name="email"
                 :label="__('Email address')"
@@ -20,7 +23,6 @@
                 placeholder="email@example.com"
             />
 
-            <!-- Password -->
             <div class="relative">
                 <flux:input
                     name="password"
@@ -31,29 +33,33 @@
                     :placeholder="__('Password')"
                     viewable
                 />
-
                 @if (Route::has('password.request'))
-                    <flux:link class="absolute top-0 text-sm end-0" :href="route('password.request')" wire:navigate>
-                        {{ __('Forgot your password?') }}
-                    </flux:link>
+                    <a href="{{ route('password.request') }}" wire:navigate
+                       class="absolute end-0 top-0 text-xs text-zinc-500 hover:text-zinc-300 transition-colors">
+                        {{ __('Forgot password?') }}
+                    </a>
                 @endif
             </div>
 
-            <!-- Remember Me -->
             <flux:checkbox name="remember" :label="__('Remember me')" :checked="old('remember')" />
 
-            <div class="flex items-center justify-end">
-                <flux:button variant="primary" type="submit" class="w-full" data-test="login-button">
-                    {{ __('Log in') }}
-                </flux:button>
-            </div>
+            <button
+                type="submit"
+                data-test="login-button"
+                class="mt-1 w-full rounded-lg bg-gradient-to-r from-blue-600 to-blue-700 px-4 py-2.5 text-sm font-semibold text-white shadow-md shadow-blue-900/40 transition hover:from-blue-500 hover:to-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-zinc-900"
+            >
+                {{ __('Sign in') }}
+            </button>
         </form>
 
         @if (Route::has('register'))
-            <div class="space-x-1 text-sm text-center rtl:space-x-reverse text-zinc-600 dark:text-zinc-400">
-                <span>{{ __('Don\'t have an account?') }}</span>
-                <flux:link :href="route('register')" wire:navigate>{{ __('Sign up') }}</flux:link>
-            </div>
+            <p class="text-center text-sm text-zinc-600">
+                {{ __("Don't have an account?") }}
+                <a href="{{ route('register') }}" wire:navigate class="font-medium text-zinc-400 hover:text-white transition-colors">
+                    {{ __('Sign up') }}
+                </a>
+            </p>
         @endif
+
     </div>
 </x-layouts::auth>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/categories', App\Livewire\Categories\Index::class)->name('categories.index');
         Route::get('/products', App\Livewire\Products\Index::class)->name('products.index');
         Route::get('/warehouses', App\Livewire\Warehouses\Index::class)->name('warehouses.index');
+        Route::get('/warehouses/{warehouse}', App\Livewire\Warehouses\Show::class)->name('warehouses.show');
         Route::get('/locations', App\Livewire\Locations\Index::class)->name('locations.index');
 
         Route::get('/users', App\Livewire\Users\Index::class)->name('users.index');


### PR DESCRIPTION
## Summary

### Sidebar overhaul
- **Background**: `bg-zinc-950` — deep dark, far from the stock zinc-50 Laravel look
- **Brand header**: blue gradient icon (`from-blue-500 to-blue-700` with shadow), bold WareTrack wordmark
- **Nav items**: new `x-nav-item` component — active state is a solid `bg-blue-600` rounded pill with white text; inactive is `text-zinc-400` with `hover:bg-zinc-800/60 hover:text-zinc-100`
- **Section headers**: 10px `uppercase tracking-widest text-zinc-600` — clean and structured
- **User footer**: shows name + role (Administrator / Warehouse Worker), chevron trigger, dropdown with Settings + Log out
- **Mobile header**: gradient icon + WareTrack text + avatar dropdown

### Login page overhaul
- **Left panel**: near-black `bg-[#080c14]` with glowing blue/indigo orb blurs, animated particle canvas, gradient logo icon, gradient headline (`from-blue-400 to-indigo-400`), mini stats grid (3 · 20 · 100%), feature bullets with coloured rings (blue/indigo/emerald)
- **Right panel**: subtle CSS grid background pattern, frosted-glass login card (`backdrop-blur`, `shadow-xl`, `border`), copyright footer
- **Auth header**: left-aligned `text-2xl font-bold` title instead of centred heading
- **GSAP**: stats cards now animate in with stagger

## Test plan
- [x] `php artisan test` — 180/180 passed
- [x] `pint --test` — clean
- [ ] Manual: verify sidebar dark theme in browser
- [ ] Manual: verify active state highlighting on each nav route
- [ ] Manual: verify login page split layout + animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)