### PR TITLE
style: align app theme with login page dark palette

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -7,6 +7,7 @@ use App\Models\Location;
 use App\Models\Product;
 use App\Models\StockMovement;
 use App\Models\Warehouse;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
@@ -49,6 +50,80 @@ class Dashboard extends Component
             ->latest()
             ->take(8)
             ->get();
+    }
+
+    /**
+     * Data for the "Movements – Last 7 Days" grouped bar chart.
+     */
+    #[Computed]
+    public function chartMovements(): array
+    {
+        $days = collect(range(6, 0))->map(fn ($i) => now()->subDays($i)->format('Y-m-d'));
+
+        $raw = DB::table('stock_movements')
+            ->selectRaw('DATE(created_at) as day, type, SUM(ABS(quantity)) as total')
+            ->whereBetween('created_at', [now()->subDays(6)->startOfDay(), now()->endOfDay()])
+            ->groupBy('day', 'type')
+            ->get()
+            ->groupBy('day');
+
+        $typeConfig = [
+            'incoming'   => ['label' => 'Incoming',   'color' => 'rgba(34,197,94,.85)'],
+            'outgoing'   => ['label' => 'Outgoing',   'color' => 'rgba(239,68,68,.85)'],
+            'transfer'   => ['label' => 'Transfer',   'color' => 'rgba(59,130,246,.85)'],
+            'correction' => ['label' => 'Correction', 'color' => 'rgba(234,179,8,.85)'],
+        ];
+
+        $labels = $days->map(fn ($d) => Carbon::parse($d)->format('D d/m'))->values()->toArray();
+
+        $datasets = [];
+        foreach ($typeConfig as $type => $cfg) {
+            $data = $days->map(
+                fn ($day) => (int) ($raw->get($day)?->firstWhere('type', $type)?->total ?? 0)
+            )->values()->toArray();
+
+            $datasets[] = [
+                'label'           => $cfg['label'],
+                'data'            => $data,
+                'backgroundColor' => $cfg['color'],
+                'borderRadius'    => 5,
+                'borderSkipped'   => false,
+            ];
+        }
+
+        return compact('labels', 'datasets');
+    }
+
+    /**
+     * Data for the "Stock by Warehouse" doughnut chart.
+     */
+    #[Computed]
+    public function chartStockByWarehouse(): array
+    {
+        $rows = DB::table('warehouses')
+            ->join('locations', 'locations.warehouse_id', '=', 'warehouses.id')
+            ->join('stock', 'stock.location_id', '=', 'locations.id')
+            ->whereNull('warehouses.deleted_at')
+            ->whereNull('locations.deleted_at')
+            ->selectRaw('warehouses.name, SUM(stock.quantity) as total')
+            ->groupBy('warehouses.id', 'warehouses.name')
+            ->orderByDesc('total')
+            ->get();
+
+        $palette = [
+            'rgba(59,130,246,.85)',
+            'rgba(139,92,246,.85)',
+            'rgba(20,184,166,.85)',
+            'rgba(245,158,11,.85)',
+            'rgba(239,68,68,.85)',
+            'rgba(236,72,153,.85)',
+        ];
+
+        return [
+            'labels' => $rows->pluck('name')->toArray(),
+            'data'   => $rows->pluck('total')->map(fn ($v) => (int) $v)->toArray(),
+            'colors' => $rows->keys()->map(fn ($i) => $palette[$i % count($palette)])->toArray(),
+        ];
     }
 
     public function render()

--- a/app/Livewire/Products/Show.php
+++ b/app/Livewire/Products/Show.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Livewire\Products;
+
+use App\Models\Product;
+use App\Models\StockMovement;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class Show extends Component
+{
+    public Product $product;
+
+    public function mount(Product $product): void
+    {
+        $this->product = $product->load(['category', 'stock.location.warehouse']);
+    }
+
+    /**
+     * Stock breakdown per location, sorted by warehouse then location code.
+     */
+    #[Computed]
+    public function stockLines()
+    {
+        return $this->product->stock()
+            ->with('location.warehouse')
+            ->get()
+            ->sortBy([
+                fn ($a, $b) => strcmp($a->location->warehouse->name ?? '', $b->location->warehouse->name ?? ''),
+                fn ($a, $b) => strcmp($a->location->code, $b->location->code),
+            ]);
+    }
+
+    /**
+     * Recent movements for this product (last 25).
+     */
+    #[Computed]
+    public function movements()
+    {
+        return StockMovement::where('product_id', $this->product->id)
+            ->with(['location.warehouse', 'fromLocation.warehouse', 'toLocation.warehouse', 'user'])
+            ->latest()
+            ->limit(25)
+            ->get();
+    }
+
+    /**
+     * Total stock across all locations.
+     */
+    #[Computed]
+    public function totalStock(): int
+    {
+        return $this->product->stock->sum('quantity');
+    }
+
+    /**
+     * Whether the product is below its minimum stock.
+     */
+    #[Computed]
+    public function isBelowMinStock(): bool
+    {
+        return $this->product->min_stock > 0 && $this->totalStock < $this->product->min_stock;
+    }
+
+    public function imageUrl(): ?string
+    {
+        return $this->product->image_path
+            ? Storage::url($this->product->image_path)
+            : null;
+    }
+
+    public function render()
+    {
+        return view('livewire.products.show', ['title' => $this->product->name]);
+    }
+}

--- a/app/Livewire/Reports/Index.php
+++ b/app/Livewire/Reports/Index.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 #[Layout('layouts.app')]
 class Index extends Component
@@ -92,6 +93,63 @@ class Index extends Component
     public function updatedFilterType(): void
     {
         unset($this->movements);
+    }
+
+    public function exportStockPerLocation(): StreamedResponse
+    {
+        $lines = app(ReportService::class)->getStockPerLocation($this->filterWarehouse ?: null);
+
+        return response()->streamDownload(function () use ($lines) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, ['Warehouse', 'Location Code', 'Location Name', 'Product', 'SKU', 'Category', 'Quantity']);
+            foreach ($lines as $line) {
+                fputcsv($handle, [
+                    $line->location->warehouse->name,
+                    $line->location->code,
+                    $line->location->name ?? '',
+                    $line->product->name,
+                    $line->product->sku,
+                    $line->product->category?->name ?? '',
+                    $line->quantity,
+                ]);
+            }
+            fclose($handle);
+        }, 'stock-per-location-'.now()->format('Y-m-d').'.csv', ['Content-Type' => 'text/csv']);
+    }
+
+    public function exportMovements(): StreamedResponse
+    {
+        $from = $this->filterFrom ? Carbon::parse($this->filterFrom) : now()->startOfMonth();
+        $to   = $this->filterTo  ? Carbon::parse($this->filterTo)   : now();
+
+        $movements = app(ReportService::class)->getMovementsForPeriod(
+            $from,
+            $to,
+            $this->filterType ?: null,
+        );
+
+        return response()->streamDownload(function () use ($movements) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, ['Date', 'Type', 'Product', 'SKU', 'Location', 'Quantity', 'Reference', 'Notes', 'User']);
+            foreach ($movements as $m) {
+                $location = $m->type->value === 'transfer'
+                    ? ($m->fromLocation?->code ?? '?').' → '.($m->toLocation?->code ?? '?')
+                    : ($m->location?->code ?? '—');
+
+                fputcsv($handle, [
+                    $m->created_at->format('Y-m-d H:i:s'),
+                    $m->type->value,
+                    $m->product->name,
+                    $m->product->sku,
+                    $location,
+                    $m->quantity,
+                    $m->reference ?? '',
+                    $m->notes ?? '',
+                    $m->user?->name ?? '',
+                ]);
+            }
+            fclose($handle);
+        }, 'movements-'.now()->format('Y-m-d').'.csv', ['Content-Type' => 'text/csv']);
     }
 
     public function render()

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -64,3 +64,40 @@ select:focus[data-flux-control] {
 /* \[:where(&)\]:size-4 {
     @apply size-4;
 } */
+
+/* ═══════════════════════════════════════
+   WareTrack dark-theme overrides
+   Body bg: #04060f — all overrides below
+   ensure Flux components stay in palette.
+   ═══════════════════════════════════════ */
+
+/* Table: transparent bg so body/card bg shows through */
+.dark [data-flux-table] table,
+.dark [data-flux-table] {
+    background: transparent !important;
+}
+
+/* Table row dividers — subtle white lines instead of zinc */
+.dark [data-flux-table] tbody tr {
+    border-color: rgba(255, 255, 255, .06) !important;
+}
+
+/* Table header cell — slightly elevated from row bg */
+.dark [data-flux-table] thead th,
+.dark [data-flux-table] tfoot td {
+    background: rgba(255, 255, 255, .035) !important;
+    border-color: rgba(255, 255, 255, .06) !important;
+}
+
+/* Modal dialog — match card glassmorphism */
+.dark [data-flux-modal] {
+    background: rgb(10, 12, 24) !important;
+    border-color: rgba(255, 255, 255, .08) !important;
+}
+
+/* Dropdown/menu panels */
+.dark [data-flux-menu],
+.dark [data-flux-select-button] {
+    background: rgb(12, 14, 26) !important;
+    border-color: rgba(255, 255, 255, .08) !important;
+}

--- a/resources/views/components/nav-item.blade.php
+++ b/resources/views/components/nav-item.blade.php
@@ -8,10 +8,11 @@
     href="{{ $href }}"
     wire:navigate
     @class([
-        'group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-100',
-        'bg-blue-600 text-white shadow-sm shadow-blue-900/40' => $active,
-        'text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100' => ! $active,
+        'group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-100',
+        'text-white shadow-sm shadow-indigo-900/50' => $active,
+        'text-zinc-400 hover:bg-white/[.06] hover:text-zinc-100' => ! $active,
     ])
+    @style(['background:linear-gradient(90deg,#4f46e5,#2563eb)' => $active])
 >
     @if($icon)
         <flux:icon

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -3,7 +3,12 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-zinc-100 dark:bg-zinc-900">
+    <body class="min-h-screen antialiased" style="background:#04060f">
+
+        {{-- Ambient glow from sidebar direction (matches login right-panel) --}}
+        <div class="pointer-events-none fixed inset-0 z-0"
+             style="background:radial-gradient(ellipse 35% 70% at 12% 50%, rgba(59,130,246,.055) 0%, transparent 60%)">
+        </div>
 
         {{-- ===== SIDEBAR ===== --}}
         <flux:sidebar sticky collapsible="mobile" class="w-60 border-e border-zinc-800/60 bg-zinc-950 dark:border-zinc-800/60 dark:bg-zinc-950">
@@ -24,7 +29,7 @@
 
                 {{-- General --}}
                 <div>
-                    <p class="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-widest text-zinc-600">{{ __('General') }}</p>
+                    <p class="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-widest text-zinc-500">{{ __('General') }}</p>
                     <div class="flex flex-col gap-0.5">
                         <x-nav-item href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')" icon="home">
                             {{ __('Dashboard') }}
@@ -47,7 +52,7 @@
                 {{-- Admin --}}
                 @if(auth()->user()?->isAdmin())
                     <div>
-                        <p class="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-widest text-zinc-600">{{ __('Admin') }}</p>
+                        <p class="mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-widest text-zinc-500">{{ __('Admin') }}</p>
                         <div class="flex flex-col gap-0.5">
                             <x-nav-item href="{{ route('categories.index') }}" :active="request()->routeIs('categories.*')" icon="tag">
                                 {{ __('Categories') }}
@@ -132,7 +137,7 @@
         </flux:sidebar>
 
         {{-- ===== MOBILE HEADER ===== --}}
-        <flux:header class="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950 lg:hidden">
+        <flux:header class="border-b border-white/[.08] lg:hidden" style="background:#04060f">
             <flux:sidebar.toggle class="text-zinc-500 lg:hidden" icon="bars-2" inset="left" />
             <div class="flex items-center gap-2">
                 <div class="flex size-6 items-center justify-center rounded bg-gradient-to-br from-blue-500 to-blue-700">

--- a/resources/views/layouts/auth/split.blade.php
+++ b/resources/views/layouts/auth/split.blade.php
@@ -4,106 +4,99 @@
         @include('partials.head')
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
         <style>
-            /* ── Aurora seam: fades canvas into right-panel bg ── */
+            /* Fade right edge of canvas into right-panel background */
             .wt-seam {
                 position: absolute;
                 inset: 0 0 0 auto;
-                width: 320px;
-                background: linear-gradient(90deg, transparent 0%, #050710 75%);
+                width: 280px;
+                background: linear-gradient(90deg, transparent 0%, #04060f 100%);
                 z-index: 8;
                 pointer-events: none;
             }
-            /* Hairline accent glow at the split edge */
+            /* Hairline divider glow */
             .wt-seam::after {
                 content: '';
                 position: absolute;
-                right: 0; top: 5%; bottom: 5%;
+                right: 0; top: 8%; bottom: 8%;
                 width: 1px;
                 background: linear-gradient(
                     to bottom,
-                    transparent 0%,
-                    rgba(129,140,248,.15) 15%,
-                    rgba(129,140,248,.55) 50%,
-                    rgba(129,140,248,.15) 85%,
-                    transparent 100%
+                    transparent,
+                    rgba(99,102,241,.4) 30%,
+                    rgba(147,197,253,.5) 50%,
+                    rgba(99,102,241,.4) 70%,
+                    transparent
                 );
             }
         </style>
     </head>
-    <body class="min-h-screen antialiased" style="background:#050710">
+    <body class="min-h-screen antialiased" style="background:#04060f">
 
-        <div class="relative grid h-dvh flex-col items-center justify-center lg:max-w-none lg:grid-cols-2 lg:px-0">
+        <div class="relative grid h-dvh lg:max-w-none lg:grid-cols-2">
 
             {{-- ══════════════════════════════════════
-                 LEFT PANEL — Aurora animation
+                 LEFT PANEL
                  ══════════════════════════════════════ --}}
-            <div class="wt-panel relative hidden h-full flex-col overflow-hidden lg:flex" style="background:#020613">
+            <div class="relative hidden h-full overflow-hidden lg:block" style="background:#020511">
 
-                {{-- Aurora canvas fills the entire panel --}}
-                <canvas id="wt-aurora" class="absolute inset-0 w-full h-full"></canvas>
-
-                {{-- Gradient seam transition --}}
+                <canvas id="wt-aurora" class="absolute inset-0 h-full w-full"></canvas>
                 <div class="wt-seam"></div>
 
-                {{-- All UI sits above the canvas --}}
-                <div class="relative z-10 flex h-full flex-col p-10 text-white">
+                {{-- UI layer --}}
+                <div class="relative z-10 flex h-full flex-col px-12 py-10 text-white">
 
-                    {{-- Logo --}}
-                    <a href="{{ route('home') }}" wire:navigate class="wt-logo flex items-center gap-3">
-                        <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-700 shadow-lg shadow-blue-900/50">
-                            <x-app-logo-icon class="h-5 w-5 fill-current text-white" />
+                    {{-- Logo top-left --}}
+                    <a href="{{ route('home') }}" wire:navigate class="wt-logo flex w-fit items-center gap-3">
+                        <span class="flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 shadow-lg shadow-blue-900/40">
+                            <x-app-logo-icon class="h-4 w-4 fill-current text-white" />
                         </span>
-                        <span class="text-xl font-bold tracking-tight">WareTrack</span>
+                        <span class="text-lg font-bold tracking-tight">WareTrack</span>
                     </a>
 
-                    {{-- Spacer --}}
-                    <div class="mt-auto">
+                    {{-- Center content --}}
+                    <div class="my-auto pb-8">
 
-                        {{-- Badge --}}
-                        <div class="wt-tagline mb-5 inline-flex items-center gap-2 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-indigo-300">
-                            <span class="size-1.5 animate-pulse rounded-full bg-indigo-400"></span>
-                            Live system
+                        <div class="wt-pill mb-6 inline-flex items-center gap-2 rounded-full border border-blue-400/25 bg-blue-500/10 px-3 py-1 text-[10.5px] font-semibold uppercase tracking-widest text-blue-300">
+                            <span class="size-1.5 animate-pulse rounded-full bg-blue-400"></span>
+                            Warehouse Management System
                         </div>
 
-                        {{-- Headline --}}
-                        <p class="wt-tagline text-[clamp(30px,3.4vw,46px)] font-extrabold leading-[1.1] tracking-tight text-white">
+                        <h1 class="wt-headline text-[clamp(28px,3vw,44px)] font-extrabold leading-[1.1] tracking-tight">
                             Control every<br>
-                            <span class="bg-gradient-to-r from-indigo-400 to-cyan-300 bg-clip-text text-transparent">warehouse</span><br>
+                            <span class="bg-gradient-to-r from-blue-400 via-indigo-300 to-cyan-300 bg-clip-text text-transparent">warehouse</span><br>
                             in real time.
+                        </h1>
+
+                        <p class="wt-sub mt-5 max-w-[300px] text-sm leading-relaxed text-white/40">
+                            Real-time inventory across multiple locations, full audit trail, low-stock alerts — all in one place.
                         </p>
 
-                        {{-- Subline --}}
-                        <p class="wt-sub mt-4 max-w-xs text-[14.5px] leading-7 text-white/45">
-                            Track inventory, manage deliveries and reduce waste — all from a single dashboard.
-                        </p>
-
-                        {{-- Stats: real counts from DB --}}
+                        {{-- Real DB counts --}}
                         @php
                             $warehouseCount = \App\Models\Warehouse::count();
                             $productCount   = \App\Models\Product::count();
                             $locationCount  = \App\Models\Location::count();
                         @endphp
-                        <div class="wt-stats mt-9 flex gap-8">
+                        <div class="wt-stats mt-10 flex gap-10">
                             <div>
-                                <p class="text-2xl font-bold tracking-tight text-white">{{ $warehouseCount }}</p>
-                                <p class="mt-1 text-[10.5px] font-medium uppercase tracking-widest text-white/35">{{ Str::plural('Warehouse', $warehouseCount) }}</p>
+                                <div class="text-2xl font-bold tracking-tight">{{ $warehouseCount }}</div>
+                                <div class="mt-1 text-[10px] font-semibold uppercase tracking-widest text-white/30">{{ Str::plural('Warehouse', $warehouseCount) }}</div>
                             </div>
                             <div>
-                                <p class="text-2xl font-bold tracking-tight text-white">{{ $productCount }}</p>
-                                <p class="mt-1 text-[10.5px] font-medium uppercase tracking-widest text-white/35">{{ Str::plural('Product', $productCount) }}</p>
+                                <div class="text-2xl font-bold tracking-tight">{{ $productCount }}</div>
+                                <div class="mt-1 text-[10px] font-semibold uppercase tracking-widest text-white/30">{{ Str::plural('Product', $productCount) }}</div>
                             </div>
                             <div>
-                                <p class="text-2xl font-bold tracking-tight text-white">{{ $locationCount }}</p>
-                                <p class="mt-1 text-[10.5px] font-medium uppercase tracking-widest text-white/35">{{ Str::plural('Location', $locationCount) }}</p>
+                                <div class="text-2xl font-bold tracking-tight">{{ $locationCount }}</div>
+                                <div class="mt-1 text-[10px] font-semibold uppercase tracking-widest text-white/30">{{ Str::plural('Location', $locationCount) }}</div>
                             </div>
                         </div>
-
                     </div>
 
-                    {{-- Bottom status --}}
-                    <div class="wt-badge mt-8">
-                        <span class="inline-flex items-center gap-1.5 text-xs text-white/30">
-                            <span class="size-1.5 rounded-full bg-emerald-400"></span>
+                    {{-- Status bottom --}}
+                    <div class="wt-status">
+                        <span class="inline-flex items-center gap-1.5 text-xs text-white/25">
+                            <span class="size-1.5 rounded-full bg-emerald-400 shadow-sm shadow-emerald-400/50"></span>
                             All systems operational
                         </span>
                     </div>
@@ -112,40 +105,40 @@
             </div>
 
             {{-- ══════════════════════════════════════
-                 RIGHT PANEL — Form card
+                 RIGHT PANEL
                  ══════════════════════════════════════ --}}
-            <div class="wt-form-panel relative flex w-full items-center justify-center overflow-hidden px-8 py-12 lg:p-12" style="background:#050710">
+            <div class="wt-form-panel relative flex h-full w-full items-center justify-center overflow-hidden px-8 py-10 lg:px-12" style="background:#04060f">
 
-                {{-- Ambient glow that bleeds in from the left-panel aurora --}}
+                {{-- Aurora bleed-in glow from left --}}
                 <div class="pointer-events-none absolute inset-0" style="background:
-                    radial-gradient(ellipse 90% 100% at 0% 50%, rgba(99,102,241,.18) 0%, transparent 60%),
-                    radial-gradient(ellipse 50% 60% at 0% 50%, rgba(56,189,248,.10) 0%, transparent 55%)
+                    radial-gradient(ellipse 100% 80% at -5% 50%, rgba(59,130,246,.14) 0%, transparent 55%),
+                    radial-gradient(ellipse 60%  60% at -5% 50%, rgba(99,102,241,.10) 0%, transparent 45%)
                 "></div>
 
-                <div class="relative mx-auto flex w-full max-w-sm flex-col gap-6">
+                <div class="relative w-full max-w-[360px]">
 
-                    {{-- Mobile logo --}}
-                    <a href="{{ route('home') }}" wire:navigate class="flex items-center gap-3 font-medium lg:hidden">
-                        <span class="flex size-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-blue-700 shadow-md">
-                            <x-app-logo-icon class="size-5 fill-current text-white" />
+                    {{-- Mobile logo only --}}
+                    <a href="{{ route('home') }}" wire:navigate class="mb-6 flex items-center gap-3 lg:hidden">
+                        <span class="flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 shadow-md">
+                            <x-app-logo-icon class="size-4 fill-current text-white" />
                         </span>
-                        <span class="text-base font-semibold text-white">WareTrack</span>
+                        <span class="text-base font-bold tracking-tight text-white">WareTrack</span>
                     </a>
 
                     {{-- Glass card --}}
-                    <div class="rounded-2xl border border-indigo-500/20 backdrop-blur-[32px]"
-                         style="background:rgba(255,255,255,.045);box-shadow:0 32px 72px rgba(0,0,0,.65),inset 0 1px 0 rgba(255,255,255,.07)">
+                    <div class="wt-card overflow-hidden rounded-2xl border border-white/[.07]"
+                         style="background:rgba(255,255,255,.04);backdrop-filter:blur(28px);-webkit-backdrop-filter:blur(28px);box-shadow:0 24px 64px rgba(0,0,0,.6),0 0 0 1px rgba(255,255,255,.03) inset">
 
                         {{-- Card header --}}
-                        <div class="flex flex-col items-center gap-3 border-b border-white/[.07] px-8 py-6">
-                            <div class="flex size-11 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-blue-600 shadow-lg shadow-indigo-900/50">
+                        <div class="flex flex-col items-center gap-2.5 border-b border-white/[.06] px-8 py-5">
+                            <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 shadow-lg shadow-blue-900/40">
                                 <x-app-logo-icon class="size-5 fill-current text-white" />
-                            </div>
-                            <p class="text-sm font-semibold text-white">WareTrack</p>
+                            </span>
+                            <span class="text-sm font-semibold text-white">WareTrack</span>
                         </div>
 
-                        {{-- Form slot --}}
-                        <div class="px-8 py-6">
+                        {{-- Form --}}
+                        <div class="px-8 py-7">
                             {{ $slot }}
                         </div>
                     </div>
@@ -156,124 +149,106 @@
         </div>
 
         @persist('toast')
-            <flux:toast.group>
-                <flux:toast />
-            </flux:toast.group>
+            <flux:toast.group><flux:toast /></flux:toast.group>
         @endpersist
-
         @fluxScripts
 
         <script>
         document.addEventListener('DOMContentLoaded', function () {
 
-            /* ════════════════════════════════════════
-               AURORA canvas animation
-               ════════════════════════════════════════ */
-            const canvas = document.getElementById('wt-aurora');
-            if (!canvas) return;
+            /* ── Aurora ──────────────────────────────── */
+            const cv = document.getElementById('wt-aurora');
+            if (!cv) return;
+            const ctx = cv.getContext('2d');
+            let W, H, t = 0, raf;
 
-            const ctx = canvas.getContext('2d');
-            let W, H, t = 0, animFrame;
-
-            function resize() {
-                W = canvas.width  = canvas.offsetWidth;
-                H = canvas.height = canvas.offsetHeight;
-            }
+            function resize() { W = cv.width = cv.offsetWidth; H = cv.height = cv.offsetHeight; }
             resize();
-            window.addEventListener('resize', () => {
-                cancelAnimationFrame(animFrame);
-                resize();
-                draw();
-            });
+            window.addEventListener('resize', () => { cancelAnimationFrame(raf); resize(); });
 
-            const mouse = { x: W / 2, y: H / 2 };
+            const mouse = { x: -1, y: -1 };
             document.addEventListener('mousemove', e => { mouse.x = e.clientX; mouse.y = e.clientY; });
 
-            /* Aurora bands — hues stay in 175–268 (cyan → blue → indigo, NO pink) */
+            /*
+              Aurora ribbons — drawn as STROKES (not filled polygons).
+              Hues are strictly blue/cyan range: 185–240.
+              Each band is:
+                1. A thick blurred stroke (glow body) with screen blend
+                2. A thin crisp stroke (bright edge)
+            */
             const bands = [
-                { y:.55, amp:.10, freq:.7,  spd:.18, h1:215, h2:248, a:.58 },
-                { y:.42, amp:.08, freq:.55, spd:.13, h1:248, h2:262, a:.48 },
-                { y:.65, amp:.12, freq:.9,  spd:.22, h1:192, h2:218, a:.42 },
-                { y:.35, amp:.07, freq:.45, spd:.10, h1:258, h2:268, a:.32 },
-                { y:.72, amp:.09, freq:1.1, spd:.28, h1:178, h2:208, a:.26 },
+                { y:.50, amp:.09, freq:.65, spd:.16, h1:210, h2:230, w:55, a:.55 },
+                { y:.40, amp:.07, freq:.50, spd:.12, h1:225, h2:240, w:40, a:.45 },
+                { y:.62, amp:.11, freq:.85, spd:.20, h1:195, h2:215, w:65, a:.42 },
+                { y:.33, amp:.06, freq:.40, spd:.09, h1:235, h2:242, w:35, a:.30 },
+                { y:.70, amp:.08, freq:1.0, spd:.24, h1:188, h2:208, w:45, a:.25 },
             ];
 
-            function pseudoRand(n) {
-                const x = Math.sin(n) * 43758.5453123;
-                return x - Math.floor(x);
+            function wavePts(b, i) {
+                const pts = [];
+                const mx = mouse.x > 0 ? mouse.x : W * .4;
+                for (let s = 0; s <= 100; s++) {
+                    const px = s / 100 * W;
+                    const nx = s / 100;
+                    const pull = Math.exp(-((px - mx) / W) * ((px - mx) / W) * 25)
+                                 * .035 * Math.sin(t * 2.5 + i);
+                    const py = H * (b.y
+                        + Math.sin(nx * Math.PI * 2.8 * b.freq + t * b.spd) * b.amp
+                        + Math.sin(nx * Math.PI * 4.5 * b.freq * .7 + t * b.spd * 1.3) * b.amp * .35
+                        + pull);
+                    pts.push([px, py]);
+                }
+                return pts;
+            }
+
+            function drawBand(pts, b) {
+                ctx.beginPath();
+                pts.forEach(([px, py], j) => j === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py));
+
+                const g = ctx.createLinearGradient(0, 0, W, 0);
+                g.addColorStop(0,    `hsla(${b.h1},85%,65%,0)`);
+                g.addColorStop(.15,  `hsla(${b.h1},85%,65%,${b.a})`);
+                g.addColorStop(.5,   `hsla(${(b.h1+b.h2)/2},85%,65%,${b.a})`);
+                g.addColorStop(.85,  `hsla(${b.h2},85%,65%,${b.a})`);
+                g.addColorStop(1,    `hsla(${b.h2},85%,65%,0)`);
+
+                ctx.strokeStyle = g;
+                ctx.lineWidth   = b.w + Math.sin(t * .6 + b.y * 10) * 8;
+                ctx.stroke();
             }
 
             function draw() {
-                animFrame = requestAnimationFrame(draw);
-                t += 0.005;
+                raf = requestAnimationFrame(draw);
+                t += .005;
                 ctx.clearRect(0, 0, W, H);
 
-                /* Deep sky gradient */
+                /* Dark sky */
                 const sky = ctx.createLinearGradient(0, 0, 0, H);
-                sky.addColorStop(0, '#020613');
-                sky.addColorStop(1, '#050c24');
+                sky.addColorStop(0, '#010411');
+                sky.addColorStop(1, '#030818');
                 ctx.fillStyle = sky;
                 ctx.fillRect(0, 0, W, H);
 
-                /* Mouse horizontal position within the panel */
-                const mx = Math.min(mouse.x, W);
-
-                /* Blurred aurora fills */
+                /* ── Glow bodies (thick blurred strokes, screen blend) ── */
                 ctx.save();
-                ctx.filter = 'blur(34px)';
-                bands.forEach((b, i) => {
-                    const pts = [];
-                    for (let s = 0; s <= 120; s++) {
-                        const px = s / 120 * W;
-                        const nx = s / 120;
-                        /* Subtle cursor ripple */
-                        const pull = Math.exp(-((px - mx) / W) * ((px - mx) / W) * 20)
-                                     * 0.04 * Math.sin(t * 3 + i);
-                        const py = H * (
-                            b.y
-                            + Math.sin(nx * Math.PI * 3 * b.freq + t * b.spd) * b.amp
-                            + Math.sin(nx * Math.PI * 5 * b.freq * 0.7 + t * b.spd * 1.4) * b.amp * 0.4
-                            + pull
-                        );
-                        pts.push([px, py]);
-                    }
-
-                    const g = ctx.createLinearGradient(0, 0, W, 0);
-                    g.addColorStop(0,    `hsla(${b.h1}, 90%, 65%, 0)`);
-                    g.addColorStop(0.25, `hsla(${b.h1}, 90%, 65%, ${b.a})`);
-                    g.addColorStop(0.5,  `hsla(${(b.h1 + b.h2) / 2}, 90%, 65%, ${b.a * 1.2})`);
-                    g.addColorStop(0.75, `hsla(${b.h2}, 90%, 65%, ${b.a})`);
-                    g.addColorStop(1,    `hsla(${b.h2}, 90%, 65%, 0)`);
-
-                    ctx.beginPath();
-                    ctx.moveTo(0, H);
-                    pts.forEach(([px, py]) => ctx.lineTo(px, py));
-                    ctx.lineTo(W, H);
-                    ctx.closePath();
-                    ctx.fillStyle = g;
-                    ctx.fill();
-                });
+                ctx.globalCompositeOperation = 'screen';
+                ctx.filter = 'blur(18px)';
+                bands.forEach((b, i) => drawBand(wavePts(b, i), b));
                 ctx.restore();
 
-                /* Crisp ribbon highlights */
+                /* ── Crisp bright ribbon edges ── */
                 ctx.save();
-                ctx.filter = 'blur(4px)';
-                bands.slice(0, 3).forEach(b => {
+                ctx.globalCompositeOperation = 'screen';
+                ctx.filter = 'blur(2.5px)';
+                bands.slice(0, 4).forEach((b, i) => {
+                    const pts = wavePts(b, i);
                     ctx.beginPath();
-                    for (let s = 0; s <= 200; s++) {
-                        const px = s / 200 * W;
-                        const nx = s / 200;
-                        const py = H * (
-                            b.y
-                            + Math.sin(nx * Math.PI * 3 * b.freq + t * b.spd) * b.amp
-                            + Math.sin(nx * Math.PI * 5 * b.freq * 0.7 + t * b.spd * 1.4) * b.amp * 0.4
-                        );
-                        s === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
-                    }
+                    pts.forEach(([px, py], j) => j === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py));
+
                     const rg = ctx.createLinearGradient(0, 0, W, 0);
                     rg.addColorStop(0,   'transparent');
-                    rg.addColorStop(0.3, `hsla(${b.h1}, 100%, 88%, .65)`);
-                    rg.addColorStop(0.7, `hsla(${b.h2}, 100%, 88%, .65)`);
+                    rg.addColorStop(.2,  `hsla(${b.h1},100%,90%,.7)`);
+                    rg.addColorStop(.8,  `hsla(${b.h2},100%,90%,.7)`);
                     rg.addColorStop(1,   'transparent');
                     ctx.strokeStyle = rg;
                     ctx.lineWidth = 1.5;
@@ -281,35 +256,34 @@
                 });
                 ctx.restore();
 
-                /* Stars */
+                /* ── Stars ── */
                 ctx.save();
-                for (let i = 0; i < 180; i++) {
-                    const sx = pseudoRand(i * 7  + 42) * W;
-                    const sy = pseudoRand(i * 13 + 42) * H * 0.55;
-                    const ss = pseudoRand(i * 3  + 42) * 1.2 + 0.3;
-                    ctx.globalAlpha = (0.4 + 0.6 * Math.sin(t * (1 + pseudoRand(i * 2)) * 2 + i)) * 0.7;
-                    ctx.fillStyle = '#fff';
+                ctx.globalCompositeOperation = 'source-over';
+                for (let i = 0; i < 200; i++) {
+                    const sx = (Math.sin(i * 7.3)  * .5 + .5) * W;
+                    const sy = (Math.sin(i * 13.7) * .5 + .5) * H * .65;
+                    const sr = (Math.sin(i * 3.1)  * .5 + .5) * 1.1 + .2;
+                    const twinkle = .35 + .65 * Math.sin(t * (1 + (Math.sin(i*2.1)*.5+.5)) * 1.8 + i);
+                    ctx.globalAlpha = twinkle * .65;
+                    ctx.fillStyle   = '#fff';
                     ctx.beginPath();
-                    ctx.arc(sx, sy, ss, 0, Math.PI * 2);
+                    ctx.arc(sx, sy, sr, 0, Math.PI * 2);
                     ctx.fill();
                 }
                 ctx.restore();
             }
-
             draw();
 
-            /* ════════════════════════════════════════
-               GSAP entrance animations
-               ════════════════════════════════════════ */
+            /* ── GSAP entrance ────────────────────────── */
             if (typeof gsap !== 'undefined') {
-                const tl = gsap.timeline({ defaults: { ease: 'power3.out' } });
-
-                tl.from('.wt-logo',        { y: -20, opacity: 0, duration: 0.6 })
-                  .from('.wt-tagline',     { y:  22, opacity: 0, duration: 0.65, stagger: 0.08 }, '-=0.3')
-                  .from('.wt-sub',         { y:  16, opacity: 0, duration: 0.5 }, '-=0.25')
-                  .from('.wt-stats > *',   { y:  12, opacity: 0, duration: 0.4, stagger: 0.09 }, '-=0.25')
-                  .from('.wt-badge',       { opacity: 0, duration: 0.4 }, '-=0.1')
-                  .from('.wt-form-panel',  { x: 28, opacity: 0, duration: 0.65 }, '-=0.75');
+                gsap.timeline({ defaults: { ease: 'power3.out' } })
+                    .from('.wt-logo',        { y: -18, opacity: 0, duration: .55 })
+                    .from('.wt-pill',        { y:  16, opacity: 0, duration: .55 }, '-=.25')
+                    .from('.wt-headline',    { y:  20, opacity: 0, duration: .6  }, '-=.3')
+                    .from('.wt-sub',         { y:  14, opacity: 0, duration: .5  }, '-=.3')
+                    .from('.wt-stats > *',   { y:  10, opacity: 0, duration: .4, stagger: .09 }, '-=.25')
+                    .from('.wt-status',      { opacity: 0, duration: .4 }, '-=.1')
+                    .from('.wt-card',        { y:  20, opacity: 0, duration: .6  }, '-=.8');
             }
         });
         </script>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,15 +1,24 @@
 <div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
 
     {{-- Hero header --}}
-    <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-blue-600 to-blue-800 px-6 py-8 text-white shadow-lg dark:from-blue-700 dark:to-blue-900">
+    <div class="relative overflow-hidden rounded-2xl border border-white/[.07] px-6 py-8 text-white shadow-xl"
+         style="background:linear-gradient(135deg,#1e1b4b 0%,#1e3a5f 45%,#0c1a3a 100%)">
+        {{-- Subtle grid overlay --}}
+        <div class="pointer-events-none absolute inset-0 opacity-[.04]"
+             style="background-image:linear-gradient(rgba(255,255,255,.6) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.6) 1px,transparent 1px);background-size:32px 32px"></div>
+        {{-- Glow blobs --}}
+        <div class="absolute -right-12 -top-12 size-48 rounded-full opacity-20"
+             style="background:radial-gradient(circle,#818cf8,transparent 70%)"></div>
+        <div class="absolute -bottom-8 right-28 size-32 rounded-full opacity-15"
+             style="background:radial-gradient(circle,#38bdf8,transparent 70%)"></div>
         <div class="relative z-10">
-            <p class="text-sm font-medium text-blue-200">{{ now()->format('l, j F Y') }}</p>
-            <h1 class="mt-1 text-3xl font-bold">{{ __('Welcome back,') }} {{ auth()->user()->name }} 👋</h1>
-            <p class="mt-1 text-blue-200">{{ __('Here\'s what\'s happening in your warehouses today.') }}</p>
+            <p class="text-xs font-semibold uppercase tracking-widest text-indigo-300/70">{{ now()->format('l, j F Y') }}</p>
+            <h1 class="mt-1.5 text-3xl font-bold tracking-tight">
+                {{ __('Welcome back,') }}
+                <span class="bg-gradient-to-r from-blue-300 via-indigo-200 to-cyan-200 bg-clip-text text-transparent">{{ auth()->user()->name }}</span>
+            </h1>
+            <p class="mt-1.5 text-sm text-indigo-200/60">{{ __("Here's what's happening in your warehouses today.") }}</p>
         </div>
-        {{-- Decorative circles --}}
-        <div class="absolute -right-8 -top-8 size-40 rounded-full bg-white/5"></div>
-        <div class="absolute -bottom-10 right-20 size-28 rounded-full bg-white/5"></div>
     </div>
 
     {{-- Stats grid --}}
@@ -17,7 +26,7 @@
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
 
         {{-- Total stock (wide) --}}
-        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
             <div class="rounded-xl bg-emerald-50 p-3 dark:bg-emerald-900/30">
                 <flux:icon.cube class="size-7 text-emerald-600 dark:text-emerald-400" />
             </div>
@@ -28,7 +37,7 @@
         </div>
 
         {{-- Movements today (wide) --}}
-        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
             <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
                 <flux:icon.arrow-path class="size-7 text-blue-600 dark:text-blue-400" />
             </div>
@@ -39,7 +48,7 @@
         </div>
 
         {{-- Low stock alert count (wide) --}}
-        <div class="col-span-2 flex items-center gap-4 rounded-xl border {{ $this->lowStockProducts->isNotEmpty() ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900' }} p-5">
+        <div class="col-span-2 flex items-center gap-4 rounded-xl border {{ $this->lowStockProducts->isNotEmpty() ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-white/[.08] bg-white dark:bg-white/[.04]' }} p-5">
             <div class="rounded-xl {{ $this->lowStockProducts->isNotEmpty() ? 'bg-red-100 dark:bg-red-900/30' : 'bg-zinc-100 dark:bg-zinc-800' }} p-3">
                 <flux:icon.exclamation-triangle class="size-7 {{ $this->lowStockProducts->isNotEmpty() ? 'text-red-600 dark:text-red-400' : 'text-zinc-400' }}" />
             </div>
@@ -53,7 +62,7 @@
     {{-- Small counters --}}
     <div class="grid gap-4 sm:grid-cols-4">
         @if($isAdmin)
-        <a href="{{ route('products.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-blue-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-700">
+        <a href="{{ route('products.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 transition hover:border-blue-300 hover:shadow-sm dark:bg-white/[.04] dark:hover:border-blue-700">
             <div class="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
                 <flux:icon.archive-box class="size-5 text-blue-600 dark:text-blue-400" />
             </div>
@@ -62,7 +71,7 @@
                 <p class="text-xs text-zinc-500">{{ __('Products') }}</p>
             </div>
         </a>
-        <a href="{{ route('categories.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-violet-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-violet-700">
+        <a href="{{ route('categories.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 transition hover:border-violet-300 hover:shadow-sm dark:bg-white/[.04] dark:hover:border-violet-700">
             <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
                 <flux:icon.tag class="size-5 text-violet-600 dark:text-violet-400" />
             </div>
@@ -71,7 +80,7 @@
                 <p class="text-xs text-zinc-500">{{ __('Categories') }}</p>
             </div>
         </a>
-        <a href="{{ route('warehouses.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-amber-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-amber-700">
+        <a href="{{ route('warehouses.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 transition hover:border-amber-300 hover:shadow-sm dark:bg-white/[.04] dark:hover:border-amber-700">
             <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
                 <flux:icon.building-office class="size-5 text-amber-600 dark:text-amber-400" />
             </div>
@@ -80,7 +89,7 @@
                 <p class="text-xs text-zinc-500">{{ __('Warehouses') }}</p>
             </div>
         </a>
-        <a href="{{ route('locations.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-green-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-green-700">
+        <a href="{{ route('locations.index') }}" wire:navigate class="group flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 transition hover:border-green-300 hover:shadow-sm dark:bg-white/[.04] dark:hover:border-green-700">
             <div class="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
                 <flux:icon.map-pin class="size-5 text-green-600 dark:text-green-400" />
             </div>
@@ -90,7 +99,7 @@
             </div>
         </a>
         @else
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
                 <flux:icon.archive-box class="size-5 text-blue-600 dark:text-blue-400" />
             </div>
@@ -99,7 +108,7 @@
                 <p class="text-xs text-zinc-500">{{ __('Products') }}</p>
             </div>
         </div>
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
                 <flux:icon.tag class="size-5 text-violet-600 dark:text-violet-400" />
             </div>
@@ -108,7 +117,7 @@
                 <p class="text-xs text-zinc-500">{{ __('Categories') }}</p>
             </div>
         </div>
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
                 <flux:icon.building-office class="size-5 text-amber-600 dark:text-amber-400" />
             </div>
@@ -117,7 +126,7 @@
                 <p class="text-xs text-zinc-500">{{ __('Warehouses') }}</p>
             </div>
         </div>
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
                 <flux:icon.map-pin class="size-5 text-green-600 dark:text-green-400" />
             </div>
@@ -133,7 +142,7 @@
     <div class="grid gap-6 lg:grid-cols-3">
 
         {{-- Movements last 7 days --}}
-        <div class="lg:col-span-2 flex flex-col rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="lg:col-span-2 flex flex-col rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
             <div class="mb-4 flex items-center gap-2">
                 <flux:icon.chart-bar class="size-5 text-zinc-400" />
                 <flux:heading>{{ __('Movements – Last 7 Days') }}</flux:heading>
@@ -144,7 +153,7 @@
         </div>
 
         {{-- Stock by warehouse --}}
-        <div class="flex flex-col rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
             <div class="mb-4 flex items-center gap-2">
                 <flux:icon.building-office class="size-5 text-zinc-400" />
                 <flux:heading>{{ __('Stock by Warehouse') }}</flux:heading>
@@ -165,7 +174,7 @@
     <div class="grid gap-6 lg:grid-cols-2">
 
         {{-- Low Stock Alerts --}}
-        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-4 rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
             <div class="flex items-center justify-between">
                 <div class="flex items-center gap-2">
                     <flux:icon.exclamation-triangle class="size-5 text-red-500" />
@@ -208,7 +217,7 @@
         </div>
 
         {{-- Recent Activity --}}
-        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-4 rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
             <div class="flex items-center gap-2">
                 <flux:icon.clock class="size-5 text-zinc-400" />
                 <flux:heading>{{ __('Recent Activity') }}</flux:heading>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -129,6 +129,38 @@
         @endif
     </div>
 
+    {{-- Charts row --}}
+    <div class="grid gap-6 lg:grid-cols-3">
+
+        {{-- Movements last 7 days --}}
+        <div class="lg:col-span-2 flex flex-col rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="mb-4 flex items-center gap-2">
+                <flux:icon.chart-bar class="size-5 text-zinc-400" />
+                <flux:heading>{{ __('Movements – Last 7 Days') }}</flux:heading>
+            </div>
+            <div wire:ignore class="relative min-h-52 flex-1">
+                <canvas id="chart-movements"></canvas>
+            </div>
+        </div>
+
+        {{-- Stock by warehouse --}}
+        <div class="flex flex-col rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="mb-4 flex items-center gap-2">
+                <flux:icon.building-office class="size-5 text-zinc-400" />
+                <flux:heading>{{ __('Stock by Warehouse') }}</flux:heading>
+            </div>
+            <div wire:ignore class="relative min-h-52 flex-1">
+                @if(count($this->chartStockByWarehouse['labels']) > 0)
+                    <canvas id="chart-warehouse"></canvas>
+                @else
+                    <div class="flex h-full items-center justify-center text-sm text-zinc-400">
+                        {{ __('No stock data yet.') }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+
     {{-- Bottom grid --}}
     <div class="grid gap-6 lg:grid-cols-2">
 
@@ -215,3 +247,76 @@
     </div>
 
 </div>
+
+@push('head-scripts')
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+@endpush
+
+@script
+<script>
+    Chart.defaults.color       = 'rgba(255,255,255,.45)';
+    Chart.defaults.borderColor = 'rgba(255,255,255,.07)';
+    Chart.defaults.font.family = 'inherit';
+
+    /* ── Movements bar chart ── */
+    const movementsEl = document.getElementById('chart-movements');
+    if (movementsEl) {
+        new Chart(movementsEl, {
+            type: 'bar',
+            data: @json($this->chartMovements),
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                        labels: { boxWidth: 10, padding: 18, font: { size: 11 } },
+                    },
+                    tooltip: { mode: 'index', intersect: false },
+                },
+                scales: {
+                    x: {
+                        grid: { display: false },
+                        border: { display: false },
+                        ticks: { font: { size: 11 } },
+                    },
+                    y: {
+                        border: { display: false },
+                        ticks: { precision: 0, font: { size: 11 } },
+                    },
+                },
+            },
+        });
+    }
+
+    /* ── Stock by warehouse doughnut ── */
+    const warehouseEl = document.getElementById('chart-warehouse');
+    if (warehouseEl) {
+        const wd = @json($this->chartStockByWarehouse);
+        new Chart(warehouseEl, {
+            type: 'doughnut',
+            data: {
+                labels: wd.labels,
+                datasets: [{
+                    data: wd.data,
+                    backgroundColor: wd.colors,
+                    borderWidth: 2,
+                    borderColor: 'rgb(24,24,27)',
+                    hoverOffset: 6,
+                }],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                        labels: { boxWidth: 10, padding: 16, font: { size: 11 } },
+                    },
+                },
+                cutout: '65%',
+            },
+        });
+    }
+</script>
+@endscript

--- a/resources/views/livewire/deliveries/create.blade.php
+++ b/resources/views/livewire/deliveries/create.blade.php
@@ -9,7 +9,7 @@
     <div class="flex max-w-2xl flex-col gap-6">
 
         {{-- Delivery info --}}
-        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-4 rounded-xl border border-white/[.08] bg-white p-6 dark:bg-white/[.04]">
             <flux:heading size="lg">{{ __('Delivery Details') }}</flux:heading>
 
             <div class="grid grid-cols-2 gap-4">
@@ -38,7 +38,7 @@
         </div>
 
         {{-- Items --}}
-        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-4 rounded-xl border border-white/[.08] bg-white p-6 dark:bg-white/[.04]">
             <div class="flex items-center justify-between">
                 <flux:heading size="lg">{{ __('Items') }}</flux:heading>
                 <flux:button wire:click="addItem" variant="ghost" size="sm" icon="plus">

--- a/resources/views/livewire/deliveries/show.blade.php
+++ b/resources/views/livewire/deliveries/show.blade.php
@@ -46,7 +46,7 @@
                 $totalReceived = $delivery->items->sum('quantity_received');
                 $pct = $totalOrdered > 0 ? round(($totalReceived / $totalOrdered) * 100) : 0;
             @endphp
-            <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-5 py-3 dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white px-5 py-3 dark:bg-white/[.04]">
                 <div>
                     <p class="text-right text-2xl font-bold text-zinc-900 dark:text-zinc-100">{{ $pct }}%</p>
                     <p class="text-xs text-zinc-500">{{ __('received') }}</p>
@@ -71,7 +71,7 @@
         @endif
 
         {{-- Items table --}}
-        <div class="flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-4 rounded-xl border border-white/[.08] bg-white p-6 dark:bg-white/[.04]">
             <flux:heading size="lg">{{ __('Delivery Items') }}</flux:heading>
 
             <flux:table>

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -59,7 +59,10 @@
                         @endif
                     </flux:table.cell>
                     <flux:table.cell variant="strong">
-                        {{ $product->name }}
+                        <a href="{{ route('products.show', $product) }}" wire:navigate
+                           class="hover:text-blue-400 transition-colors">
+                            {{ $product->name }}
+                        </a>
                     </flux:table.cell>
 
                     <flux:table.cell>
@@ -82,6 +85,13 @@
                         <flux:dropdown>
                             <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
                             <flux:menu>
+                                <flux:menu.item
+                                    icon="eye"
+                                    :href="route('products.show', $product)"
+                                    wire:navigate
+                                >
+                                    {{ __('View') }}
+                                </flux:menu.item>
                                 <flux:menu.item
                                     icon="pencil"
                                     wire:click="openEdit({{ $product->id }})"

--- a/resources/views/livewire/products/show.blade.php
+++ b/resources/views/livewire/products/show.blade.php
@@ -1,0 +1,234 @@
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+
+    {{-- Back + header --}}
+    <div class="flex items-start justify-between gap-4">
+        <div class="flex items-center gap-4">
+            <flux:button :href="route('products.index')" wire:navigate icon="arrow-left" variant="ghost" size="sm" />
+            <div>
+                <div class="flex items-center gap-3">
+                    <flux:heading size="xl">{{ $product->name }}</flux:heading>
+                    @if($this->isBelowMinStock)
+                        <flux:badge variant="danger" icon="exclamation-triangle" size="sm">
+                            {{ __('Low Stock') }}
+                        </flux:badge>
+                    @endif
+                </div>
+                <flux:subheading>
+                    {{ $product->category?->name ?? __('No category') }} ·
+                    <span class="font-mono tracking-tight">{{ $product->sku }}</span>
+                </flux:subheading>
+            </div>
+        </div>
+
+        <div class="flex shrink-0 gap-2">
+            <flux:button
+                :href="route('stock.movements.create')"
+                wire:navigate
+                icon="plus"
+                variant="primary"
+                size="sm"
+            >
+                {{ __('Register Movement') }}
+            </flux:button>
+        </div>
+    </div>
+
+    {{-- Top info row --}}
+    <div class="grid gap-6 lg:grid-cols-3">
+
+        {{-- Product card --}}
+        <div class="flex flex-col gap-5 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
+            {{-- Image --}}
+            @if($this->imageUrl())
+                <img
+                    src="{{ $this->imageUrl() }}"
+                    alt="{{ $product->name }}"
+                    class="h-36 w-full rounded-lg object-cover"
+                />
+            @else
+                <div class="flex h-36 w-full items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800">
+                    <flux:icon.photo class="size-12 text-zinc-300 dark:text-zinc-600" />
+                </div>
+            @endif
+
+            {{-- Details --}}
+            <dl class="flex flex-col gap-2 text-sm">
+                <div class="flex justify-between">
+                    <dt class="text-zinc-500">{{ __('SKU') }}</dt>
+                    <dd class="font-mono font-medium">{{ $product->sku }}</dd>
+                </div>
+                <div class="flex justify-between">
+                    <dt class="text-zinc-500">{{ __('Category') }}</dt>
+                    <dd class="font-medium">{{ $product->category?->name ?? '—' }}</dd>
+                </div>
+                <div class="flex justify-between">
+                    <dt class="text-zinc-500">{{ __('Min. Stock') }}</dt>
+                    <dd class="font-medium">{{ $product->min_stock }}</dd>
+                </div>
+                <div class="flex justify-between">
+                    <dt class="text-zinc-500">{{ __('Added') }}</dt>
+                    <dd class="font-medium">{{ $product->created_at->format('d M Y') }}</dd>
+                </div>
+            </dl>
+
+            @if($product->description)
+                <p class="text-sm leading-relaxed text-zinc-500">{{ $product->description }}</p>
+            @endif
+        </div>
+
+        {{-- Stock summary cards --}}
+        <div class="lg:col-span-2 flex flex-col gap-4">
+
+            {{-- Total stock + min stock --}}
+            <div class="grid gap-4 sm:grid-cols-2">
+                <div class="flex items-center gap-4 rounded-xl border
+                    {{ $this->isBelowMinStock ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900' }}
+                    p-5">
+                    <div class="rounded-xl {{ $this->isBelowMinStock ? 'bg-red-100 dark:bg-red-900/30' : 'bg-emerald-50 dark:bg-emerald-900/30' }} p-3">
+                        <flux:icon.cube class="size-7 {{ $this->isBelowMinStock ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400' }}" />
+                    </div>
+                    <div>
+                        <p class="text-3xl font-bold {{ $this->isBelowMinStock ? 'text-red-700 dark:text-red-400' : 'text-zinc-900 dark:text-zinc-100' }}">
+                            {{ number_format($this->totalStock) }}
+                        </p>
+                        <p class="text-sm {{ $this->isBelowMinStock ? 'text-red-500' : 'text-zinc-500' }}">{{ __('Total in stock') }}</p>
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+                    <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
+                        <flux:icon.map-pin class="size-7 text-blue-600 dark:text-blue-400" />
+                    </div>
+                    <div>
+                        <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
+                            {{ $this->stockLines->count() }}
+                        </p>
+                        <p class="text-sm text-zinc-500">{{ __('Active locations') }}</p>
+                    </div>
+                </div>
+            </div>
+
+            {{-- Stock per location table --}}
+            <div class="flex-1 rounded-xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+                <div class="flex items-center gap-2 border-b border-zinc-100 px-5 py-4 dark:border-zinc-800">
+                    <flux:icon.map-pin class="size-4 text-zinc-400" />
+                    <flux:heading>{{ __('Stock per Location') }}</flux:heading>
+                </div>
+
+                @if($this->stockLines->isEmpty())
+                    <div class="flex flex-col items-center justify-center px-5 py-10 text-center">
+                        <flux:icon.cube class="mb-2 size-8 text-zinc-300 dark:text-zinc-600" />
+                        <p class="text-sm text-zinc-400">{{ __('No stock recorded for this product.') }}</p>
+                    </div>
+                @else
+                    <div class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                        @foreach($this->stockLines as $stock)
+                            @php $pct = $product->min_stock > 0 ? min(100, round($stock->quantity / $product->min_stock * 100)) : 100; @endphp
+                            <div class="flex items-center gap-4 px-5 py-3">
+                                <div class="min-w-0 flex-1">
+                                    <p class="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                        {{ $stock->location->code }}
+                                        @if($stock->location->name)
+                                            <span class="text-zinc-400"> — {{ $stock->location->name }}</span>
+                                        @endif
+                                    </p>
+                                    <p class="text-xs text-zinc-400">{{ $stock->location->warehouse->name }}</p>
+                                </div>
+                                <div class="w-32">
+                                    <div class="h-1.5 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                                        <div
+                                            class="h-full rounded-full {{ $pct < 100 ? 'bg-red-400' : 'bg-emerald-400' }}"
+                                            style="width: {{ $pct }}%"
+                                        ></div>
+                                    </div>
+                                </div>
+                                <div class="w-16 text-right">
+                                    <span class="text-sm font-bold {{ $stock->quantity === 0 ? 'text-zinc-400' : 'text-zinc-900 dark:text-zinc-100' }}">
+                                        {{ number_format($stock->quantity) }}
+                                    </span>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    {{-- Movement history --}}
+    <div class="rounded-xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center justify-between border-b border-zinc-100 px-6 py-4 dark:border-zinc-800">
+            <div class="flex items-center gap-2">
+                <flux:icon.clock class="size-4 text-zinc-400" />
+                <flux:heading>{{ __('Recent Movements') }}</flux:heading>
+            </div>
+            <a href="{{ route('stock.movements') }}" wire:navigate
+               class="text-xs text-zinc-400 hover:text-zinc-200 transition-colors">
+                {{ __('View all') }} →
+            </a>
+        </div>
+
+        @if($this->movements->isEmpty())
+            <div class="flex flex-col items-center justify-center px-6 py-10 text-center">
+                <flux:icon.clock class="mb-2 size-8 text-zinc-300 dark:text-zinc-600" />
+                <p class="text-sm text-zinc-400">{{ __('No movements recorded yet.') }}</p>
+            </div>
+        @else
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>{{ __('Type') }}</flux:table.column>
+                    <flux:table.column>{{ __('Location') }}</flux:table.column>
+                    <flux:table.column>{{ __('Qty') }}</flux:table.column>
+                    <flux:table.column>{{ __('Reference') }}</flux:table.column>
+                    <flux:table.column>{{ __('By') }}</flux:table.column>
+                    <flux:table.column>{{ __('When') }}</flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach($this->movements as $movement)
+                        @php
+                            $typeColors = [
+                                'incoming'   => 'success',
+                                'outgoing'   => 'danger',
+                                'transfer'   => 'blue',
+                                'correction' => 'warning',
+                            ];
+                            $typeColor = $typeColors[$movement->type->value] ?? 'zinc';
+                        @endphp
+                        <flux:table.row :key="$movement->id">
+                            <flux:table.cell>
+                                <flux:badge variant="{{ $typeColor }}" size="sm">
+                                    {{ ucfirst($movement->type->value) }}
+                                </flux:badge>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                @if($movement->type->value === 'transfer')
+                                    <span class="text-xs">
+                                        {{ $movement->fromLocation?->code ?? '?' }}
+                                        → {{ $movement->toLocation?->code ?? '?' }}
+                                    </span>
+                                @else
+                                    <span class="text-xs">{{ $movement->location?->code ?? '—' }}</span>
+                                @endif
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <span class="font-mono font-semibold {{ $movement->quantity > 0 ? 'text-emerald-500' : ($movement->quantity < 0 ? 'text-red-500' : 'text-zinc-400') }}">
+                                    {{ $movement->quantity > 0 ? '+' : '' }}{{ $movement->quantity }}
+                                </span>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <span class="text-xs text-zinc-400">{{ $movement->reference ?? '—' }}</span>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <span class="text-xs">{{ $movement->user?->name ?? '—' }}</span>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <span class="text-xs text-zinc-400">{{ $movement->created_at->diffForHumans() }}</span>
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+        @endif
+    </div>
+
+</div>

--- a/resources/views/livewire/products/show.blade.php
+++ b/resources/views/livewire/products/show.blade.php
@@ -37,7 +37,7 @@
     <div class="grid gap-6 lg:grid-cols-3">
 
         {{-- Product card --}}
-        <div class="flex flex-col gap-5 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-5 rounded-xl border border-white/[.08] bg-white p-6 dark:bg-white/[.04]">
             {{-- Image --}}
             @if($this->imageUrl())
                 <img
@@ -82,7 +82,7 @@
             {{-- Total stock + min stock --}}
             <div class="grid gap-4 sm:grid-cols-2">
                 <div class="flex items-center gap-4 rounded-xl border
-                    {{ $this->isBelowMinStock ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900' }}
+                    {{ $this->isBelowMinStock ? 'border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-900/10' : 'border-white/[.08] bg-white dark:bg-white/[.04]' }}
                     p-5">
                     <div class="rounded-xl {{ $this->isBelowMinStock ? 'bg-red-100 dark:bg-red-900/30' : 'bg-emerald-50 dark:bg-emerald-900/30' }} p-3">
                         <flux:icon.cube class="size-7 {{ $this->isBelowMinStock ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400' }}" />
@@ -95,7 +95,7 @@
                     </div>
                 </div>
 
-                <div class="flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-900">
+                <div class="flex items-center gap-4 rounded-xl border border-white/[.08] bg-white p-5 dark:bg-white/[.04]">
                     <div class="rounded-xl bg-blue-50 p-3 dark:bg-blue-900/30">
                         <flux:icon.map-pin class="size-7 text-blue-600 dark:text-blue-400" />
                     </div>
@@ -109,7 +109,7 @@
             </div>
 
             {{-- Stock per location table --}}
-            <div class="flex-1 rounded-xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="flex-1 rounded-xl border border-white/[.08] bg-white dark:bg-white/[.04]">
                 <div class="flex items-center gap-2 border-b border-zinc-100 px-5 py-4 dark:border-zinc-800">
                     <flux:icon.map-pin class="size-4 text-zinc-400" />
                     <flux:heading>{{ __('Stock per Location') }}</flux:heading>
@@ -156,7 +156,7 @@
     </div>
 
     {{-- Movement history --}}
-    <div class="rounded-xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+    <div class="rounded-xl border border-white/[.08] bg-white dark:bg-white/[.04]">
         <div class="flex items-center justify-between border-b border-zinc-100 px-6 py-4 dark:border-zinc-800">
             <div class="flex items-center gap-2">
                 <flux:icon.clock class="size-4 text-zinc-400" />

--- a/resources/views/livewire/reports/index.blade.php
+++ b/resources/views/livewire/reports/index.blade.php
@@ -7,7 +7,7 @@
     </div>
 
     {{-- Tabs --}}
-    <div class="flex gap-1 border-b border-zinc-200 dark:border-zinc-700">
+    <div class="flex gap-1 border-b border-white/[.08]">
         <button
             wire:click="setTab('low-stock')"
             class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition {{ $tab === 'low-stock' ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300' }}"

--- a/resources/views/livewire/reports/index.blade.php
+++ b/resources/views/livewire/reports/index.blade.php
@@ -85,6 +85,15 @@
                 </flux:select>
             </div>
             <span class="text-sm text-zinc-400">{{ $this->stockPerLocation->count() }} {{ __('lines') }}</span>
+            <flux:button
+                wire:click="exportStockPerLocation"
+                icon="arrow-down-tray"
+                variant="ghost"
+                size="sm"
+                class="ml-auto"
+            >
+                {{ __('Export CSV') }}
+            </flux:button>
         </div>
 
         @if($this->stockPerLocation->isEmpty())
@@ -149,6 +158,15 @@
                 </flux:select>
             </flux:field>
             <p class="mb-2 text-sm text-zinc-400">{{ $this->movements->count() }} {{ __('movements') }}</p>
+            <flux:button
+                wire:click="exportMovements"
+                icon="arrow-down-tray"
+                variant="ghost"
+                size="sm"
+                class="mb-2 ml-auto"
+            >
+                {{ __('Export CSV') }}
+            </flux:button>
         </div>
 
         @if($this->movements->isEmpty())

--- a/resources/views/livewire/stock/create-movement.blade.php
+++ b/resources/views/livewire/stock/create-movement.blade.php
@@ -7,7 +7,7 @@
     </div>
 
     <div class="max-w-xl">
-        <div class="flex flex-col gap-6 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex flex-col gap-6 rounded-xl border border-white/[.08] bg-white p-6 dark:bg-white/[.04]">
 
             {{-- Type --}}
             <flux:field>

--- a/resources/views/livewire/warehouses/index.blade.php
+++ b/resources/views/livewire/warehouses/index.blade.php
@@ -22,7 +22,7 @@
 
     {{-- Card Grid --}}
     @if ($this->warehouses->isEmpty())
-        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 py-20 text-center dark:border-zinc-700">
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-white/[.10] py-20 text-center">
             <div class="mb-3 rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
                 <flux:icon.building-office class="size-8 text-zinc-400" />
             </div>
@@ -35,7 +35,7 @@
     @else
         <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             @foreach ($this->warehouses as $warehouse)
-                <div class="group relative flex flex-col gap-4 rounded-xl border border-zinc-200 bg-white p-5 transition duration-200 hover:border-blue-300 hover:shadow-lg dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-700">
+                <div class="group relative flex flex-col gap-4 rounded-xl border border-white/[.08] bg-white p-5 transition duration-200 hover:border-blue-300 hover:shadow-lg dark:bg-white/[.04] dark:hover:border-blue-700">
 
                     {{-- Top row --}}
                     <div class="flex items-start justify-between">

--- a/resources/views/livewire/warehouses/show.blade.php
+++ b/resources/views/livewire/warehouses/show.blade.php
@@ -31,7 +31,7 @@
 
     {{-- Stats bar --}}
     <div class="grid grid-cols-3 gap-4">
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-violet-50 p-2 dark:bg-violet-900/30">
                 <flux:icon.map-pin class="size-5 text-violet-600 dark:text-violet-400" />
             </div>
@@ -41,7 +41,7 @@
             </div>
         </div>
 
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-emerald-50 p-2 dark:bg-emerald-900/30">
                 <flux:icon.cube class="size-5 text-emerald-600 dark:text-emerald-400" />
             </div>
@@ -51,7 +51,7 @@
             </div>
         </div>
 
-        <div class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="flex items-center gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
             <div class="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
                 <flux:icon.tag class="size-5 text-amber-600 dark:text-amber-400" />
             </div>
@@ -64,7 +64,7 @@
 
     {{-- Locations --}}
     @if ($this->locations->isEmpty())
-        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 py-20 text-center dark:border-zinc-700">
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-white/[.10] py-20 text-center">
             <div class="mb-3 rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
                 <flux:icon.map-pin class="size-8 text-zinc-400" />
             </div>
@@ -75,7 +75,7 @@
     @else
         <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             @foreach ($this->locations as $location)
-                <div class="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+                <div class="flex flex-col gap-3 rounded-xl border border-white/[.08] bg-white p-4 dark:bg-white/[.04]">
 
                     {{-- Code + actions --}}
                     <div class="flex items-start justify-between">

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -13,3 +13,5 @@
 
 @vite(['resources/css/app.css', 'resources/js/app.js'])
 @fluxAppearance
+
+@stack('head-scripts')

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::middleware(['admin'])->group(function () {
         Route::get('/categories', App\Livewire\Categories\Index::class)->name('categories.index');
         Route::get('/products', App\Livewire\Products\Index::class)->name('products.index');
+        Route::get('/products/{product}', App\Livewire\Products\Show::class)->name('products.show');
         Route::get('/warehouses', App\Livewire\Warehouses\Index::class)->name('warehouses.index');
         Route::get('/warehouses/{warehouse}', App\Livewire\Warehouses\Show::class)->name('warehouses.show');
         Route::get('/locations', App\Livewire\Locations\Index::class)->name('locations.index');


### PR DESCRIPTION
## Summary

Makes the entire app interior visually consistent with the login page.

- **Body**: `#04060f` everywhere (was `zinc-100`/`zinc-900`)
- **Ambient glow**: subtle blue radial gradient from sidebar direction (mirrors the login right panel's ambient from the aurora panel)
- **Cards**: `border-white/[.08]` + `dark:bg-white/[.04]` — same glassmorphism as the login card
- **Dashboard hero**: replaced bright blue gradient with deep indigo gradient (`#1e1b4b → #1e3a5f → #0c1a3a`) + grid overlay + glow blobs
- **Nav-item active**: `linear-gradient(90deg, #4f46e5, #2563eb)` — matches login "Sign in" button
- **Mobile header**: `#04060f` background + `border-white/[.08]`
- **Dashed empty states**: `border-white/[.10]`
- **Flux overrides** (app.css): table bg transparent, table dividers `rgba(255,255,255,.06)`, modal/dropdown backgrounds match palette

## Test plan

- [ ] Visit dashboard — deep dark bg, glassmorphic cards, indigo hero
- [ ] Navigate all pages — consistent background and card style
- [ ] Mobile view — header matches
- [ ] Login → dashboard transition feels cohesive