### PR TITLE
fix(ui): responsive layout improvements

### DIFF
--- a/resources/views/livewire/activity/index.blade.php
+++ b/resources/views/livewire/activity/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Activity Log') }}</flux:heading>
             <flux:subheading>{{ __('Full audit trail of all stock movements across all users and locations') }}</flux:subheading>
@@ -30,7 +30,7 @@
 
     {{-- Filters --}}
     <div class="flex flex-wrap items-end gap-3">
-        <div class="w-64">
+        <div class="w-full sm:w-64">
             <flux:input
                 wire:model.live.debounce.300ms="search"
                 icon="magnifying-glass"

--- a/resources/views/livewire/categories/index.blade.php
+++ b/resources/views/livewire/categories/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Categories') }}</flux:heading>
             <flux:subheading>{{ __('Organise your products into logical groups') }}</flux:subheading>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Hero header --}}
     <div class="relative overflow-hidden rounded-2xl border border-white/[.07] px-6 py-8 text-white shadow-xl"

--- a/resources/views/livewire/deliveries/create.blade.php
+++ b/resources/views/livewire/deliveries/create.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
     <div class="flex items-center gap-4">

--- a/resources/views/livewire/deliveries/index.blade.php
+++ b/resources/views/livewire/deliveries/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Deliveries') }}</flux:heading>
             <flux:subheading>{{ __('Incoming deliveries and their processing status') }}</flux:subheading>

--- a/resources/views/livewire/deliveries/show.blade.php
+++ b/resources/views/livewire/deliveries/show.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Back + Header --}}
     <div>

--- a/resources/views/livewire/locations/index.blade.php
+++ b/resources/views/livewire/locations/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Locations') }}</flux:heading>
             <flux:subheading>{{ __('Storage positions within your warehouses') }}</flux:subheading>

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Products') }}</flux:heading>
             <flux:subheading>{{ __('Manage your product catalogue, SKUs and categories') }}</flux:subheading>
@@ -247,7 +247,7 @@
                 </div>
             @endif
 
-            <div class="flex items-center justify-between">
+            <div class="flex flex-wrap items-center justify-between gap-y-3">
                 <flux:text class="text-sm text-zinc-400">
                     {{ count($selectedLocations) }} {{ __('selected') }}
                 </flux:text>

--- a/resources/views/livewire/reports/index.blade.php
+++ b/resources/views/livewire/reports/index.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
     <div>

--- a/resources/views/livewire/stock/bulk-correction.blade.php
+++ b/resources/views/livewire/stock/bulk-correction.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
     <div class="flex items-center gap-4">

--- a/resources/views/livewire/stock/create-movement.blade.php
+++ b/resources/views/livewire/stock/create-movement.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
     <div class="flex items-center gap-4">

--- a/resources/views/livewire/stock/index.blade.php
+++ b/resources/views/livewire/stock/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Stock Overview') }}</flux:heading>
             <flux:subheading>{{ __('Current stock levels per product and location') }}</flux:subheading>

--- a/resources/views/livewire/stock/movements.blade.php
+++ b/resources/views/livewire/stock/movements.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Stock Movements') }}</flux:heading>
             <flux:subheading>{{ __('Full history of all incoming, outgoing, transfer and correction events') }}</flux:subheading>

--- a/resources/views/livewire/suppliers/index.blade.php
+++ b/resources/views/livewire/suppliers/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Suppliers') }}</flux:heading>
             <flux:subheading>{{ __('Manage your product suppliers and their contact information') }}</flux:subheading>

--- a/resources/views/livewire/users/index.blade.php
+++ b/resources/views/livewire/users/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <flux:heading size="xl">{{ __('Users') }}</flux:heading>
         <flux:button wire:click="openCreate" variant="primary" icon="plus">
             {{ __('New User') }}

--- a/resources/views/livewire/warehouses/index.blade.php
+++ b/resources/views/livewire/warehouses/index.blade.php
@@ -1,7 +1,7 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Header --}}
-    <div class="flex items-center justify-between">
+    <div class="flex flex-wrap items-center justify-between gap-y-3">
         <div>
             <flux:heading size="xl">{{ __('Warehouses') }}</flux:heading>
             <flux:subheading>{{ __('Manage your warehouse locations and storage capacity') }}</flux:subheading>

--- a/resources/views/livewire/warehouses/show.blade.php
+++ b/resources/views/livewire/warehouses/show.blade.php
@@ -1,4 +1,4 @@
-<div class="flex h-full w-full flex-1 flex-col gap-6 p-6">
+<div class="flex h-full w-full flex-1 flex-col gap-6 p-4 sm:p-6">
 
     {{-- Back + Header --}}
     <div>


### PR DESCRIPTION
## Summary

- Page headers with action buttons now use `flex-wrap` so on small/tablet screens the title and buttons stack gracefully instead of overflowing
- All pages get `p-4 sm:p-6` so content isn't edge-to-edge on mobile
- Activity log search input goes full-width on mobile (`w-full sm:w-64`)

## Test plan

- [ ] Resize browser to tablet width (~768px) — headers should wrap, not overflow
- [ ] Check all list pages: Stock, Movements, Categories, Products, Suppliers, Locations, Users, Warehouses, Deliveries, Activity