### PR TITLE
fix(docs): correct DeliveryStatus in rules.md

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -272,7 +272,7 @@ enum StockMovementType: string
 enum DeliveryStatus: string
 {
     case Pending = 'pending';
-    case Processing = 'processing';
+    case Partial = 'partial';
     case Received = 'received';
 }
 ```


### PR DESCRIPTION
The actual enum uses Partial not Processing — align the docs with the real code.