### PR TITLE
feat(stock): add movements list navigation

### DIFF
--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -37,6 +37,13 @@
                         <x-nav-item href="{{ route('stock.index') }}" :active="request()->routeIs('stock.*')" icon="cube">
                             {{ __('Stock') }}
                         </x-nav-item>
+                        @if(request()->routeIs('stock.*'))
+                            <div class="ml-4 flex flex-col gap-0.5 border-l border-white/10 pl-1.5">
+                                <x-nav-item href="{{ route('stock.movements') }}" :active="request()->routeIs('stock.movements')" icon="list-bullet">
+                                    {{ __('Movements') }}
+                                </x-nav-item>
+                            </div>
+                        @endif
                         <x-nav-item href="{{ route('reports.index') }}" :active="request()->routeIs('reports.*')" icon="chart-bar">
                             {{ __('Reports') }}
                         </x-nav-item>

--- a/resources/views/livewire/stock/index.blade.php
+++ b/resources/views/livewire/stock/index.blade.php
@@ -7,6 +7,9 @@
             <flux:subheading>{{ __('Current stock levels per product and location') }}</flux:subheading>
         </div>
         <div class="flex items-center gap-2">
+            <flux:button :href="route('stock.movements')" wire:navigate variant="ghost" icon="list-bullet">
+                {{ __('Movements') }}
+            </flux:button>
             <flux:button :href="route('stock.bulk-correction')" wire:navigate variant="ghost" icon="pencil-square">
                 {{ __('Bulk Correction') }}
             </flux:button>


### PR DESCRIPTION
Adds a UI entry point to the stock movement history (`stock.movements`), which previously had no link.

- **Movements button** in the stock overview header (next to Bulk Correction and Register Movement)
- **Contextual sub-item** under "Stock" in the sidebar, shown while browsing the stock section

Verified locally: 232 Pest tests green (481 assertions), Pint clean, assets built.