### PR TITLE
fix(deliveries): render timeline status icon via dynamic :icon prop

### DIFF
--- a/resources/views/livewire/deliveries/show.blade.php
+++ b/resources/views/livewire/deliveries/show.blade.php
@@ -127,7 +127,7 @@
                             @if (! $step['done'] && ! $isLast)
                                 <span class="size-2 rounded-full bg-zinc-500"></span>
                             @else
-                                <flux:icon.{{ $step['icon'] }} class="size-4 text-white" />
+                                <flux:icon :icon="$step['icon']" class="size-4 text-white" />
                             @endif
                         </div>
 


### PR DESCRIPTION
The delivery status timeline rendered the Flux icon via a **dynamic component tag name** (`<flux:icon.{{ $step['icon'] }}>`). Blade resolves component tags at compile time, so a runtime variable in the tag name doesn't work and breaks the view.

Fixed by passing the icon name as a runtime prop: `<flux:icon :icon="$step['icon']" />` — matching the existing pattern in the sidebar nav item.

- 232 Pest tests green (`DeliveryTest` renders `Show` via `Livewire::test`)
- No other dynamic-tag-name usage in the views